### PR TITLE
Extend ToolConfig to handle JsonSchema for tool parameters

### DIFF
--- a/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolConfig.java
+++ b/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolConfig.java
@@ -1,5 +1,6 @@
 package org.finos.fluxnova.ai.mcp.server.registry;
 
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import org.finos.fluxnova.ai.mcp.server.model.ToolHandler;
 
 import java.util.Map;
@@ -13,6 +14,7 @@ public record ToolConfig(
         String name,
         String description,
         Map<String, ParameterSpec> parameters,
+        JsonSchema rawSchema,
         ToolHandler handler
 ) {
     /**
@@ -60,9 +62,23 @@ public record ToolConfig(
     }
 
     /**
-     * Convenience constructor without parameters
+     * Convenience constructor without parameters (no schema)
      */
     public ToolConfig(String name, String description, ToolHandler handler) {
-        this(name, description, Map.of(), handler);
+        this(name, description, Map.of(), null, handler);
+    }
+
+    /**
+     * Convenience constructor with parameter specs (no raw schema)
+     */
+    public ToolConfig(String name, String description, Map<String, ParameterSpec> parameters, ToolHandler handler) {
+        this(name, description, parameters, null, handler);
+    }
+
+    /**
+     * Convenience constructor with raw JSON schema (no parameter specs)
+     */
+    public ToolConfig(String name, String description, JsonSchema rawSchema, ToolHandler handler) {
+        this(name, description, Map.of(), rawSchema, handler);
     }
 }

--- a/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolRegistry.java
+++ b/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolRegistry.java
@@ -146,9 +146,12 @@ public class ToolRegistry {
 
     /**
      * Builds an MCP Tool from a ToolConfig.
+     * Uses the raw JSON schema if provided, otherwise builds one from parameter specs.
      */
     private Tool buildTool(ToolConfig config) {
-        JsonSchema schema = buildJsonSchema(config.parameters());
+        JsonSchema schema = config.rawSchema() != null
+                ? config.rawSchema()
+                : buildJsonSchema(config.parameters());
 
         return new Tool(
                 config.name(),

--- a/agentic/mcp-server-plugin/src/test/java/org/finos/fluxnova/ai/mcp/server/registry/ToolConfigTest.java
+++ b/agentic/mcp-server-plugin/src/test/java/org/finos/fluxnova/ai/mcp/server/registry/ToolConfigTest.java
@@ -1,8 +1,10 @@
 package org.finos.fluxnova.ai.mcp.server.registry;
 
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import org.finos.fluxnova.ai.mcp.server.model.ToolHandler;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -101,5 +103,54 @@ class ToolConfigTest {
     void shouldThrowExceptionForBlankParameterType() {
         assertThrows(IllegalArgumentException.class,
                 () -> new ToolConfig.ParameterSpec("", true));
+    }
+
+    // rawSchema tests
+
+    @Test
+    void shouldCreateConfigWithRawSchema() {
+        ToolHandler handler = args -> "result";
+        JsonSchema schema = new JsonSchema(
+                "object",
+                Map.of("field1", Map.of("type", "string")),
+                List.of("field1"),
+                null, null, null
+        );
+
+        ToolConfig config = new ToolConfig("SchemaTool", "Tool with schema", schema, handler);
+
+        assertEquals("SchemaTool", config.name());
+        assertNotNull(config.rawSchema());
+        assertEquals("object", config.rawSchema().type());
+        assertTrue(config.parameters().isEmpty());
+    }
+
+    @Test
+    void shouldCreateConfigWithParametersAndNullRawSchema() {
+        ToolHandler handler = args -> "result";
+        Map<String, ToolConfig.ParameterSpec> params = Map.of(
+                "param1", ToolConfig.ParameterSpec.required("string")
+        );
+
+        ToolConfig config = new ToolConfig("Tool", "Desc", params, handler);
+
+        assertNull(config.rawSchema());
+        assertEquals(1, config.parameters().size());
+    }
+
+    @Test
+    void shouldCreateConfigWithBothParametersAndRawSchema() {
+        ToolHandler handler = args -> "result";
+        Map<String, ToolConfig.ParameterSpec> params = Map.of(
+                "param1", ToolConfig.ParameterSpec.required("string")
+        );
+        JsonSchema schema = new JsonSchema(
+                "object", Map.of(), null, null, null, null
+        );
+
+        ToolConfig config = new ToolConfig("Tool", "Desc", params, schema, handler);
+
+        assertNotNull(config.rawSchema());
+        assertEquals(1, config.parameters().size());
     }
 }

--- a/agentic/mcp-server-plugin/src/test/java/org/finos/fluxnova/ai/mcp/server/registry/ToolRegistryTest.java
+++ b/agentic/mcp-server-plugin/src/test/java/org/finos/fluxnova/ai/mcp/server/registry/ToolRegistryTest.java
@@ -3,6 +3,7 @@ package org.finos.fluxnova.ai.mcp.server.registry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import org.finos.fluxnova.ai.mcp.server.model.ToolHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -171,5 +173,57 @@ class ToolRegistryTest {
         boolean result = toolRegistry.register(config);
 
         assertFalse(result);
+    }
+
+    @Test
+    void shouldRegisterToolWithRawSchema() {
+        ToolHandler handler = args -> "result";
+        JsonSchema schema = new JsonSchema(
+                "object",
+                Map.of("field1", Map.of("type", "string", "description", "A field")),
+                List.of("field1"),
+                null, null, null
+        );
+        ToolConfig config = new ToolConfig("SchemaTool", "Tool with raw schema", schema, handler);
+
+        boolean result = toolRegistry.register(config);
+
+        assertTrue(result);
+        assertTrue(toolRegistry.isRegistered("SchemaTool"));
+
+        ArgumentCaptor<SyncToolSpecification> specCaptor =
+                ArgumentCaptor.forClass(SyncToolSpecification.class);
+        verify(mcpServer).addTool(specCaptor.capture());
+
+        var tool = specCaptor.getValue().tool();
+        assertNotNull(tool.inputSchema());
+        assertEquals("object", tool.inputSchema().type());
+        assertTrue(tool.inputSchema().properties().containsKey("field1"));
+        assertEquals(List.of("field1"), tool.inputSchema().required());
+    }
+
+    @Test
+    void shouldPreferRawSchemaOverParameters() {
+        ToolHandler handler = args -> "result";
+        Map<String, ToolConfig.ParameterSpec> params = Map.of(
+                "param1", ToolConfig.ParameterSpec.required("string")
+        );
+        JsonSchema schema = new JsonSchema(
+                "object",
+                Map.of("custom", Map.of("type", "number")),
+                null, null, null, null
+        );
+        ToolConfig config = new ToolConfig("Tool", "Desc", params, schema, handler);
+
+        toolRegistry.register(config);
+
+        ArgumentCaptor<SyncToolSpecification> specCaptor =
+                ArgumentCaptor.forClass(SyncToolSpecification.class);
+        verify(mcpServer).addTool(specCaptor.capture());
+
+        var tool = specCaptor.getValue().tool();
+        // Should use rawSchema, not parameters
+        assertTrue(tool.inputSchema().properties().containsKey("custom"));
+        assertFalse(tool.inputSchema().properties().containsKey("param1"));
     }
 }


### PR DESCRIPTION
Extends ToolConfig to accept a JsonSchema argument for tool parameters. This allows for more descriptive MCP tool parameters. An example where this is used can be found [here](https://github.com/tom-stavert/fluxnova-plugins/pull/2).

@pieter-schutte 