### PR TITLE
FLUXNOVA-AI-ISSUE-10 - Expose MCP startup scanner bugs via failing tests

### DIFF
--- a/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/McpStartupScanner.java
+++ b/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/McpStartupScanner.java
@@ -82,7 +82,7 @@ public class McpStartupScanner {
             docFactory.setNamespaceAware(true);
             Document doc = docFactory.newDocumentBuilder().parse(bpmnStream);
 
-            NodeList startEvents = doc.getElementsByTagName("startEvent");
+            NodeList startEvents = doc.getElementsByTagName("bpmn:startEvent");
             int count = 0;
 
             for (int i = 0; i < startEvents.getLength(); i++) {

--- a/agentic/mcp-process-start-event/src/test/java/org/finos/fluxnova/ai/mcp/process/engine/McpStartupScannerTest.java
+++ b/agentic/mcp-process-start-event/src/test/java/org/finos/fluxnova/ai/mcp/process/engine/McpStartupScannerTest.java
@@ -7,11 +7,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 class McpStartupScannerTest {
 
@@ -55,19 +56,21 @@ class McpStartupScannerTest {
 
         String bpmnXml = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
-              <process id="testProcess">
-                <startEvent id="start"/>
-              </process>
-            </definitions>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                              xmlns:mcp="http://fluxnova.finos.org/schema/1.0/ai/mcp">
+              <bpmn:process id="testProcess">
+                <bpmn:startEvent id="start" mcp:toolName="myTool" mcp:description="A test tool"/>
+              </bpmn:process>
+            </bpmn:definitions>
             """;
 
-        InputStream bpmnStream = new ByteArrayInputStream(bpmnXml.getBytes());
-        when(repositoryService.getProcessModel("process-def-1")).thenReturn(bpmnStream);
+        when(repositoryService.getProcessModel("process-def-1"))
+                .thenReturn(new ByteArrayInputStream(bpmnXml.getBytes()));
 
         scanner.scanAndRegisterExistingProcesses();
 
         verify(repositoryService).getProcessModel("process-def-1");
+        verify(extractor, times(1)).extract(any(), eq("testProcess"));
     }
 
     @Test
@@ -120,9 +123,9 @@ class McpStartupScannerTest {
 
         String bpmnXml = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
-              <process id="test"><startEvent id="start"/></process>
-            </definitions>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+              <bpmn:process id="test"><bpmn:startEvent id="start"/></bpmn:process>
+            </bpmn:definitions>
             """;
 
         when(repositoryService.getProcessModel("process-1"))

--- a/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolConfig.java
+++ b/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolConfig.java
@@ -1,5 +1,6 @@
 package org.finos.fluxnova.ai.mcp.server.registry;
 
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import org.finos.fluxnova.ai.mcp.server.model.ToolHandler;
 
 import java.util.Map;
@@ -13,6 +14,7 @@ public record ToolConfig(
         String name,
         String description,
         Map<String, ParameterSpec> parameters,
+        JsonSchema rawSchema,
         ToolHandler handler
 ) {
     /**
@@ -60,9 +62,23 @@ public record ToolConfig(
     }
 
     /**
-     * Convenience constructor without parameters
+     * Convenience constructor without parameters (no schema)
      */
     public ToolConfig(String name, String description, ToolHandler handler) {
-        this(name, description, Map.of(), handler);
+        this(name, description, Map.of(), null, handler);
+    }
+
+    /**
+     * Convenience constructor with parameter specs (no raw schema)
+     */
+    public ToolConfig(String name, String description, Map<String, ParameterSpec> parameters, ToolHandler handler) {
+        this(name, description, parameters, null, handler);
+    }
+
+    /**
+     * Convenience constructor with raw JSON schema (no parameter specs)
+     */
+    public ToolConfig(String name, String description, JsonSchema rawSchema, ToolHandler handler) {
+        this(name, description, Map.of(), rawSchema, handler);
     }
 }


### PR DESCRIPTION
Fixes the bpmn: namespace mismatch in McpStartupScanner so start events are correctly found, and modifies a test to properly fail, surfacing the subsequent ClassCastException when casting org.w3c.dom.Element to Flowable's internal Element type.