### PR TITLE
Agent Configuration Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,17 @@
 .env.development.local
 .env.test.local
 .env.production.local
+
+.idea
+target
+.classpath
+.project
+.settings
+*.iml
+*.sublime-project
+*.sublime-workspace
+*.h2.db
+*.lock.db
+**/node_modules
+**/target
+*.DS_Store

--- a/backend/agentic/agent-config/pom.xml
+++ b/backend/agentic/agent-config/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.finos.fluxnova.bpm</groupId>
+    <artifactId>fluxnova-engine-plugins-ai-agentic</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>fluxnova-engine-plugins-ai-agent-config</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Fluxnova Platform - engine plugins - ai - agent config</name>
+  <description>Resolves agent configuration from BPMN ad-hoc subprocess extension elements</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.finos.fluxnova.bpm</groupId>
+      <artifactId>fluxnova-engine-plugins-shared</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.finos.fluxnova.bpm</groupId>
+      <artifactId>fluxnova-engine</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.finos.fluxnova.bpm.springboot</groupId>
+      <artifactId>fluxnova-bpm-spring-boot-starter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigAutoConfiguration.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigAutoConfiguration.java
@@ -1,0 +1,40 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.autoconfigure;
+
+import org.finos.fluxnova.bpm.engine.RepositoryService;
+import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigExtractor;
+import org.finos.fluxnova.bpm.engine.ai.agent.lifecycle.AgentConfigUndeployListener;
+import org.finos.fluxnova.bpm.engine.ai.agent.registry.AgentConfigRegistry;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@ConditionalOnBean(RepositoryService.class)
+public class AgentConfigAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentConfigExtractor agentConfigExtractor() {
+        return new AgentConfigExtractor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentConfigRegistry agentConfigRegistry(RepositoryService repositoryService,
+                                                   AgentConfigExtractor extractor) {
+        return new AgentConfigRegistry(repositoryService, extractor);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentConfigUndeployListener agentConfigUndeployListener(AgentConfigRegistry registry) {
+        return new AgentConfigUndeployListener(registry);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentConfigEnginePlugin agentConfigEnginePlugin() {
+        return new AgentConfigEnginePlugin();
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigEnginePlugin.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigEnginePlugin.java
@@ -1,0 +1,22 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.autoconfigure;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.parser.AgentConfigParseListener;
+import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.BpmnParseListener;
+import org.finos.fluxnova.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AgentConfigEnginePlugin extends AbstractProcessEnginePlugin {
+
+    @Override
+    public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+        List<BpmnParseListener> listeners = processEngineConfiguration.getCustomPostBPMNParseListeners();
+        if (listeners == null) {
+            listeners = new ArrayList<>();
+            processEngineConfiguration.setCustomPostBPMNParseListeners(listeners);
+        }
+        listeners.add(new AgentConfigParseListener());
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigElementWalker.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigElementWalker.java
@@ -1,0 +1,24 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.extract;
+
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AgentConfigElementWalker {
+
+    public List<Element> walk(Element root) {
+        return collect(root);
+    }
+
+    private List<Element> collect(Element parent) {
+        List<Element> elements = new ArrayList<>();
+        for (Element child : parent.elements()) {
+            elements.add(child);
+            if (!"extensionElements".equals(child.getTagName())) {
+                elements.addAll(collect(child));
+            }
+        }
+        return elements;
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigExtractor.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigExtractor.java
@@ -1,0 +1,75 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.extract;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.shared.xml.BpmnXmlParser;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants.AGENT_NS;
+
+public class AgentConfigExtractor {
+
+    private final AgentConfigElementWalker walker;
+
+    public AgentConfigExtractor() {
+        this(new AgentConfigElementWalker());
+    }
+
+    AgentConfigExtractor(AgentConfigElementWalker walker) {
+        this.walker = walker;
+    }
+
+    public List<AgentConfig> extractAll(InputStream bpmnXml, String processDefinitionId) {
+        String processKey = extractProcessKey(processDefinitionId);
+        List<AgentConfig> results = new ArrayList<>();
+        Parse parse = new BpmnXmlParser().createParse().sourceInputStream(bpmnXml).execute();
+        Element root = parse.getRootElement();
+        for (Element process : root.elements("process")) {
+            if (!processKey.equals(process.attribute("id"))) {
+                continue;
+            }
+            for (Element element : walker.walk(process)) {
+                extract(element, processDefinitionId).ifPresent(results::add);
+            }
+        }
+        return results;
+    }
+
+    private static String extractProcessKey(String processDefinitionId) {
+        int colonIndex = processDefinitionId.indexOf(':');
+        return colonIndex >= 0 ? processDefinitionId.substring(0, colonIndex) : processDefinitionId;
+    }
+
+    public Optional<AgentConfig> extract(Element element, String processDefinitionId) {
+        Element ext = element.element("extensionElements");
+        if (ext == null) {
+            return Optional.empty();
+        }
+
+        Element config = ext.elementNS(AGENT_NS, "config");
+        if (config == null) {
+            return Optional.empty();
+        }
+
+        String elementId = element.attribute("id");
+        String provider = config.attribute("provider");
+        String model = config.attribute("model");
+        String systemPrompt = config.attribute("systemPrompt");
+
+        String toolScopeElementId = config.attribute("toolScopeElementId");
+        if (isBlankOrNull(toolScopeElementId)) {
+            toolScopeElementId = elementId;
+        }
+
+        return Optional.of(new AgentConfig(processDefinitionId, elementId, provider, model, systemPrompt, toolScopeElementId));
+    }
+
+    private static boolean isBlankOrNull(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigValidator.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigValidator.java
@@ -1,0 +1,35 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.extract;
+
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public final class AgentConfigValidator {
+
+    private AgentConfigValidator() {}
+
+    public static List<String> validate(Element configElement, String elementId, Set<String> processElementIds) {
+        List<String> errors = new ArrayList<>();
+
+        if (isBlankOrNull(configElement.attribute("provider"))) {
+            errors.add("agent:config on element '" + elementId + "' is missing required attribute 'provider'");
+        }
+        if (isBlankOrNull(configElement.attribute("model"))) {
+            errors.add("agent:config on element '" + elementId + "' is missing required attribute 'model'");
+        }
+
+        String toolScopeElementId = configElement.attribute("toolScopeElementId");
+        if (!isBlankOrNull(toolScopeElementId) && !processElementIds.contains(toolScopeElementId)) {
+            errors.add("agent:config on element '" + elementId
+                    + "' references unknown toolScopeElementId '" + toolScopeElementId + "'");
+        }
+
+        return errors;
+    }
+
+    private static boolean isBlankOrNull(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/lifecycle/AgentConfigUndeployListener.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/lifecycle/AgentConfigUndeployListener.java
@@ -1,0 +1,19 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.lifecycle;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.registry.AgentConfigRegistry;
+import org.finos.fluxnova.bpm.spring.boot.starter.event.PreUndeployEvent;
+import org.springframework.context.event.EventListener;
+
+public class AgentConfigUndeployListener {
+
+    private final AgentConfigRegistry registry;
+
+    public AgentConfigUndeployListener(AgentConfigRegistry registry) {
+        this.registry = registry;
+    }
+
+    @EventListener
+    public void onPreUndeploy(PreUndeployEvent event) {
+        registry.unregisterAll();
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/model/AgentConfig.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/model/AgentConfig.java
@@ -1,0 +1,21 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.model;
+
+/**
+ * Immutable agent configuration extracted from a BPMN element.
+ *
+ * @param processDefinitionId process definition that owns the configured element
+ * @param elementId           BPMN element id carrying the agent configuration
+ * @param provider            AI provider identifier (e.g. {@code "ollama"}, {@code "huggingface"})
+ * @param model               model identifier within the provider (e.g. {@code "llama3"}, {@code "mistral"})
+ * @param systemPrompt        system prompt text supplied to the agent, may be {@code null}
+ * @param toolScopeElementId  BPMN element id that defines the tool-resolution scope; when omitted
+ *                            in BPMN, this defaults to {@code elementId}
+ */
+public record AgentConfig(
+    String processDefinitionId,
+    String elementId,
+    String provider,
+    String model,
+    String systemPrompt,
+    String toolScopeElementId
+) {}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListener.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListener.java
@@ -3,12 +3,11 @@ package org.finos.fluxnova.bpm.engine.ai.agent.parser;
 import org.finos.fluxnova.bpm.engine.BpmnParseException;
 import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigElementWalker;
 import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigValidator;
-import org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants;
 import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
 import org.finos.fluxnova.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+import org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -27,8 +26,6 @@ public class AgentConfigParseListener extends AbstractBpmnParseListener {
 
     @Override
     public void parseRootElement(Element rootElement, List<ProcessDefinitionEntity> processDefinitions) {
-        List<String> errors = new ArrayList<>();
-        Element offendingElement = null;
 
         for (Element process : rootElement.elements("process")) {
             List<Element> walked = walker.walk(process);
@@ -44,15 +41,10 @@ public class AgentConfigParseListener extends AbstractBpmnParseListener {
                     continue;
                 }
                 List<String> elementErrors = AgentConfigValidator.validate(config, element.attribute("id"), elementIds);
-                if (!elementErrors.isEmpty() && offendingElement == null) {
-                    offendingElement = element;
+                if (!elementErrors.isEmpty()) {
+                    throw new BpmnParseException(String.join("; ", elementErrors), element);
                 }
-                errors.addAll(elementErrors);
             }
-        }
-
-        if (!errors.isEmpty()) {
-            throw new BpmnParseException(String.join("; ", errors), offendingElement);
         }
     }
 

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListener.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListener.java
@@ -1,0 +1,73 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.parser;
+
+import org.finos.fluxnova.bpm.engine.BpmnParseException;
+import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigElementWalker;
+import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigValidator;
+import org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants;
+import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.finos.fluxnova.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class AgentConfigParseListener extends AbstractBpmnParseListener {
+
+    private final AgentConfigElementWalker walker;
+
+    public AgentConfigParseListener() {
+        this(new AgentConfigElementWalker());
+    }
+
+    AgentConfigParseListener(AgentConfigElementWalker walker) {
+        this.walker = walker;
+    }
+
+    @Override
+    public void parseRootElement(Element rootElement, List<ProcessDefinitionEntity> processDefinitions) {
+        List<String> errors = new ArrayList<>();
+        Element offendingElement = null;
+
+        for (Element process : rootElement.elements("process")) {
+            List<Element> walked = walker.walk(process);
+            Set<String> elementIds = collectElementIds(process, walked);
+
+            for (Element element : walked) {
+                Element ext = element.element("extensionElements");
+                if (ext == null) {
+                    continue;
+                }
+                Element config = ext.elementNS(AgentModelConstants.AGENT_NS, "config");
+                if (config == null) {
+                    continue;
+                }
+                List<String> elementErrors = AgentConfigValidator.validate(config, element.attribute("id"), elementIds);
+                if (!elementErrors.isEmpty() && offendingElement == null) {
+                    offendingElement = element;
+                }
+                errors.addAll(elementErrors);
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new BpmnParseException(String.join("; ", errors), offendingElement);
+        }
+    }
+
+    private static Set<String> collectElementIds(Element process, List<Element> walked) {
+        Set<String> ids = new HashSet<>();
+        String processId = process.attribute("id");
+        if (processId != null) {
+            ids.add(processId);
+        }
+        for (Element element : walked) {
+            String id = element.attribute("id");
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
+}

--- a/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/registry/AgentConfigRegistry.java
+++ b/backend/agentic/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/registry/AgentConfigRegistry.java
@@ -1,0 +1,87 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.registry;
+
+import org.finos.fluxnova.bpm.engine.AuthorizationException;
+import org.finos.fluxnova.bpm.engine.RepositoryService;
+import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigExtractor;
+import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.exception.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Central lookup for agent configurations attached to BPMN elements.
+ *
+ * <p><b>Usage:</b>
+ * <pre>{@code
+ * Optional<AgentConfig> config = registry.resolve(processDefinitionId, elementId);
+ * }</pre>
+ *
+ * @see AgentConfig
+ */
+public class AgentConfigRegistry {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgentConfigRegistry.class);
+
+    private final ConcurrentHashMap<String, HashMap<String, AgentConfig>> configCache = new ConcurrentHashMap<>();
+
+    private final RepositoryService repositoryService;
+    private final AgentConfigExtractor extractor;
+
+    /**
+     * Creates a new registry backed by the given repository service and extractor.
+     *
+     * @param repositoryService service used to fetch BPMN XML for process definitions
+     * @param extractor         strategy for parsing agent configuration from BPMN XML
+     */
+    public AgentConfigRegistry(RepositoryService repositoryService, AgentConfigExtractor extractor) {
+        this.repositoryService = repositoryService;
+        this.extractor = extractor;
+    }
+
+    /**
+     * Resolves the agent configuration for a specific BPMN element within a process definition.
+     *
+     * @param processDefinitionId the process definition to look up
+     * @param elementId           the BPMN element whose agent configuration is requested
+     * @return the configuration if the element has one, otherwise empty
+     * @throws NotFoundException      if the process definition does not exist
+     * @throws AuthorizationException if the caller lacks access to the process definition
+     */
+    public Optional<AgentConfig> resolve(String processDefinitionId, String elementId) {
+        HashMap<String, AgentConfig> definitionConfigs = configCache.computeIfAbsent(
+                processDefinitionId, this::doScan);
+        return Optional.ofNullable(definitionConfigs.get(elementId));
+    }
+
+    /**
+     * Clears all cached agent configurations.
+     *
+     * <p>Typically invoked on process undeployment to ensure stale entries are
+     * not served after redeployment.
+     */
+    public void unregisterAll() {
+        configCache.clear();
+    }
+
+    private HashMap<String, AgentConfig> doScan(String processDefinitionId) {
+        InputStream xml;
+        try {
+            xml = repositoryService.getProcessModel(processDefinitionId);
+        } catch (NotFoundException e) {
+            LOG.error("Process definition '{}' not found", processDefinitionId, e);
+            throw e;
+        } catch (AuthorizationException e) {
+            LOG.error("Unauthorized process definition access attempt on '{}'", processDefinitionId, e);
+            throw e;
+        }
+        return extractor.extractAll(xml, processDefinitionId).stream()
+                .collect(Collectors.toMap(AgentConfig::elementId, config -> config,
+                        (a, b) -> b, HashMap::new));
+    }
+}

--- a/backend/agentic/agent-config/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/backend/agentic/agent-config/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.finos.fluxnova.bpm.engine.ai.agent.autoconfigure.AgentConfigAutoConfiguration

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigAutoConfigurationTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigAutoConfigurationTest.java
@@ -1,0 +1,66 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.autoconfigure;
+
+import org.finos.fluxnova.bpm.engine.RepositoryService;
+import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigExtractor;
+import org.finos.fluxnova.bpm.engine.ai.agent.lifecycle.AgentConfigUndeployListener;
+import org.finos.fluxnova.bpm.engine.ai.agent.registry.AgentConfigRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class AgentConfigAutoConfigurationTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) context.close();
+    }
+
+    @Configuration
+    static class MockInfrastructure {
+        @Bean
+        RepositoryService repositoryService() {
+            return mock(RepositoryService.class);
+        }
+    }
+
+    @Test
+    void contextLoads_allBeansPresent() {
+        context = new AnnotationConfigApplicationContext(MockInfrastructure.class, AgentConfigAutoConfiguration.class);
+
+        assertNotNull(context.getBean(AgentConfigExtractor.class));
+        assertNotNull(context.getBean(AgentConfigRegistry.class));
+        assertNotNull(context.getBean(AgentConfigUndeployListener.class));
+        assertNotNull(context.getBean(AgentConfigEnginePlugin.class));
+    }
+
+    @Configuration
+    static class CustomExtractorOverride {
+        static final AgentConfigExtractor CUSTOM = new AgentConfigExtractor();
+
+        @Bean
+        RepositoryService repositoryService() {
+            return mock(RepositoryService.class);
+        }
+
+        @Bean
+        AgentConfigExtractor agentConfigExtractor() {
+            return CUSTOM;
+        }
+    }
+
+    @Test
+    void conditionalOnMissingBean_allowsConsumerToOverrideExtractor() {
+        context = new AnnotationConfigApplicationContext(CustomExtractorOverride.class, AgentConfigAutoConfiguration.class);
+
+        assertSame(CustomExtractorOverride.CUSTOM, context.getBean(AgentConfigExtractor.class));
+    }
+}

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigAutoConfigurationTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigAutoConfigurationTest.java
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigEnginePluginTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/autoconfigure/AgentConfigEnginePluginTest.java
@@ -1,0 +1,48 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.autoconfigure;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.parser.AgentConfigParseListener;
+import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.BpmnParseListener;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.finos.fluxnova.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentConfigEnginePluginTest {
+
+    private final AgentConfigEnginePlugin plugin = new AgentConfigEnginePlugin();
+
+    @Test
+    void preInit_whenListenerListNull_initialisesAndRegistersListener() {
+        ProcessEngineConfigurationImpl config = new StandaloneInMemProcessEngineConfiguration();
+        config.setCustomPostBPMNParseListeners(null);
+
+        plugin.preInit(config);
+
+        List<BpmnParseListener> listeners = config.getCustomPostBPMNParseListeners();
+        assertNotNull(listeners);
+        assertEquals(1, listeners.size());
+        assertTrue(listeners.get(0) instanceof AgentConfigParseListener);
+    }
+
+    @Test
+    void preInit_whenListenerListExists_appendsListenerWithoutClobbering() {
+        ProcessEngineConfigurationImpl config = new StandaloneInMemProcessEngineConfiguration();
+        BpmnParseListener existing = new AgentConfigParseListener();
+        List<BpmnParseListener> existingList = new ArrayList<>();
+        existingList.add(existing);
+        config.setCustomPostBPMNParseListeners(existingList);
+
+        plugin.preInit(config);
+
+        List<BpmnParseListener> listeners = config.getCustomPostBPMNParseListeners();
+        assertEquals(2, listeners.size());
+        assertTrue(listeners.get(0) == existing);
+        assertTrue(listeners.get(1) instanceof AgentConfigParseListener);
+    }
+}

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigExtractorTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigExtractorTest.java
@@ -1,0 +1,329 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.extract;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.shared.xml.BpmnXmlParser;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentConfigExtractorTest {
+
+    private static final String PROCESS_DEFINITION_ID = "proc:1";
+
+    private AgentConfigExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new AgentConfigExtractor();
+    }
+
+    private Element parseAdHocSubProcess(String bpmn) {
+        BpmnXmlParser parser = new BpmnXmlParser();
+        Parse parse = parser.createParse()
+                .sourceInputStream(new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)))
+                .execute();
+        return parse.getRootElement()
+                .element("process")
+                .element("adHocSubProcess");
+    }
+
+    private String wrapInProcess(String innerXml) {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="proc">
+                    %s
+                  </process>
+                </definitions>
+                """.formatted(innerXml);
+    }
+
+    // extract(Element, ...) valid config and defaulting
+
+    @Test
+    void extract_whenValidAgentConfig_returnsPopulatedAgentConfig() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="creditCheckAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="You are a credit analyst."
+                                  toolScopeElementId="creditCheckAgent"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+
+        Optional<AgentConfig> result = extractor.extract(parseAdHocSubProcess(bpmn), PROCESS_DEFINITION_ID);
+
+        assertTrue(result.isPresent());
+        AgentConfig config = result.get();
+        assertEquals(PROCESS_DEFINITION_ID, config.processDefinitionId());
+        assertEquals("creditCheckAgent", config.elementId());
+        assertEquals("ollama", config.provider());
+        assertEquals("llama3.1", config.model());
+        assertEquals("You are a credit analyst.", config.systemPrompt());
+        assertEquals("creditCheckAgent", config.toolScopeElementId());
+    }
+
+    @Test
+    void extract_whenToolScopeAbsent_defaultsToElementId() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="You are an assistant."/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+
+        Optional<AgentConfig> result = extractor.extract(parseAdHocSubProcess(bpmn), PROCESS_DEFINITION_ID);
+
+        assertTrue(result.isPresent());
+        assertEquals("myAgent", result.get().toolScopeElementId());
+    }
+
+    @Test
+    void extract_whenToolScopeBlank_defaultsToElementId() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="You are an assistant."
+                                  toolScopeElementId=""/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+
+        Optional<AgentConfig> result = extractor.extract(parseAdHocSubProcess(bpmn), PROCESS_DEFINITION_ID);
+
+        assertTrue(result.isPresent());
+        assertEquals("myAgent", result.get().toolScopeElementId());
+    }
+
+    // extract(Element, ...) missing and invalid config
+
+    @Test
+    void extract_whenNoExtensionElements_returnsEmpty() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="sub1"/>
+                """);
+
+        Optional<AgentConfig> result = extractor.extract(parseAdHocSubProcess(bpmn), PROCESS_DEFINITION_ID);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void extract_whenExtensionElementsButNoAgentConfig_returnsEmpty() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:other="http://example.com/other">
+                  <process id="p">
+                    <adHocSubProcess id="sub1">
+                      <extensionElements>
+                        <other:config provider="x"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        Optional<AgentConfig> result = extractor.extract(parseAdHocSubProcess(bpmn), PROCESS_DEFINITION_ID);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void extract_whenSystemPromptAbsent_returnsConfigWithNullSystemPrompt() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+
+        Optional<AgentConfig> result = extractor.extract(parseAdHocSubProcess(bpmn), PROCESS_DEFINITION_ID);
+
+        assertTrue(result.isPresent());
+        assertNull(result.get().systemPrompt());
+        assertEquals("ollama", result.get().provider());
+        assertEquals("llama3.1", result.get().model());
+    }
+
+    // extractAll(...) tool-scope discovery
+
+    @Test
+    void extractAll_whenToolScopeReferencesSiblingElement_succeeds() {
+        String bpmn = wrapInProcess("""
+                <subProcess id="toolRegistry"/>
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="You are an assistant."
+                                  toolScopeElementId="toolRegistry"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(1, results.size());
+        assertEquals("toolRegistry", results.get(0).toolScopeElementId());
+    }
+
+    // extractAll(...) discovery across BPMN structures
+
+    @Test
+    void extractAll_findsAgentConfigOnServiceTask() {
+        String bpmn = wrapInProcess("""
+                <serviceTask id="taskAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="Task agent."/>
+                  </extensionElements>
+                </serviceTask>
+                """);
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(1, results.size());
+        assertEquals("taskAgent", results.get(0).elementId());
+        assertEquals("taskAgent", results.get(0).toolScopeElementId());
+    }
+
+    @Test
+    void extractAll_findsAdHocSubProcessInsideSubProcess() {
+        String bpmn = wrapInProcess("""
+                <subProcess id="outer">
+                  <adHocSubProcess id="nestedAgent">
+                    <extensionElements>
+                      <agent:config provider="ollama"
+                                    model="llama3.1"
+                                    systemPrompt="Nested agent."/>
+                    </extensionElements>
+                  </adHocSubProcess>
+                </subProcess>
+                """);
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(1, results.size());
+        assertEquals("nestedAgent", results.get(0).elementId());
+    }
+
+    @Test
+    void extractAll_findsAdHocSubProcessInsideEventSubProcess() {
+        String bpmn = wrapInProcess("""
+                <subProcess id="eventSub" triggeredByEvent="true">
+                  <adHocSubProcess id="eventAgent">
+                    <extensionElements>
+                      <agent:config provider="ollama"
+                                    model="llama3.1"
+                                    systemPrompt="Event agent."/>
+                    </extensionElements>
+                  </adHocSubProcess>
+                </subProcess>
+                """);
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(1, results.size());
+        assertEquals("eventAgent", results.get(0).elementId());
+    }
+
+    @Test
+    void extractAll_findsAdHocSubProcessInsideTransaction() {
+        String bpmn = wrapInProcess("""
+                <transaction id="tx1">
+                  <adHocSubProcess id="transactionAgent">
+                    <extensionElements>
+                      <agent:config provider="ollama"
+                                    model="llama3.1"
+                                    systemPrompt="Transaction agent."/>
+                    </extensionElements>
+                  </adHocSubProcess>
+                </transaction>
+                """);
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(1, results.size());
+        assertEquals("transactionAgent", results.get(0).elementId());
+    }
+
+    @Test
+    void extractAll_findsMultipleAdHocSubProcessesInOneProcess() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="agentA">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1" systemPrompt="Agent A."/>
+                  </extensionElements>
+                </adHocSubProcess>
+                <adHocSubProcess id="agentB">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1" systemPrompt="Agent B."/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(2, results.size());
+        assertEquals("agentA", results.get(0).elementId());
+        assertEquals("agentB", results.get(1).elementId());
+    }
+
+    @Test
+    void extractAll_onlyWalksProcessMatchingProcessDefinitionId() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="proc">
+                    <adHocSubProcess id="agentP1">
+                      <extensionElements>
+                        <agent:config provider="ollama" model="llama3.1" systemPrompt="P1 agent."/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                  <process id="other">
+                    <adHocSubProcess id="agentOther">
+                      <extensionElements>
+                        <agent:config provider="ollama" model="llama3.1" systemPrompt="Other agent."/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        List<AgentConfig> results = extractor.extractAll(
+                new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)), PROCESS_DEFINITION_ID);
+
+        assertEquals(1, results.size());
+        assertEquals("agentP1", results.get(0).elementId());
+    }
+}

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigValidatorTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigValidatorTest.java
@@ -1,0 +1,217 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.extract;
+
+import org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants;
+import org.finos.fluxnova.bpm.engine.shared.xml.BpmnXmlParser;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentConfigValidatorTest {
+
+    private Element parseConfigElement(String bpmn) {
+        BpmnXmlParser parser = new BpmnXmlParser();
+        Parse parse = parser.createParse()
+                .sourceInputStream(new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)))
+                .execute();
+        return parse.getRootElement()
+                .element("process")
+                .element("adHocSubProcess")
+                .element("extensionElements")
+                .elementNS(AgentModelConstants.AGENT_NS, "config");
+    }
+
+    private String wrapInProcess(String innerXml) {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="p">
+                    %s
+                  </process>
+                </definitions>
+                """.formatted(innerXml);
+    }
+
+    @Test
+    void validate_whenAllRequiredAttrsPresent_returnsNoErrors() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="You are an assistant."/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertTrue(errors.isEmpty(), "Expected no errors but got: " + errors);
+    }
+
+    @Test
+    void validate_whenSystemPromptMissing_returnsNoErrors() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertTrue(errors.isEmpty(), "systemPrompt should be optional but got: " + errors);
+    }
+
+    @Test
+    void validate_whenProviderMissing_returnsError() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config model="llama3.1" systemPrompt="x"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("provider"));
+        assertTrue(errors.get(0).contains("myAgent"));
+    }
+
+    @Test
+    void validate_whenProviderBlank_returnsError() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="" model="llama3.1" systemPrompt="x"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("provider"));
+    }
+
+    @Test
+    void validate_whenModelMissing_returnsError() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama" systemPrompt="x"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("model"));
+        assertTrue(errors.get(0).contains("myAgent"));
+    }
+
+    @Test
+    void validate_whenProviderAndModelBothMissing_returnsBothErrors() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config systemPrompt="x"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertEquals(2, errors.size());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("provider")));
+        assertTrue(errors.stream().anyMatch(e -> e.contains("model")));
+    }
+
+    @Test
+    void validate_whenToolScopeElementIdReferencesUnknownElement_returnsError() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1"
+                                  toolScopeElementId="doesNotExist"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("doesNotExist"));
+        assertTrue(errors.get(0).contains("myAgent"));
+    }
+
+    @Test
+    void validate_whenToolScopeElementIdAbsent_doesNotValidateReference() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void validate_whenToolScopeElementIdBlank_doesNotValidateReference() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1"
+                                  toolScopeElementId=""/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent", Set.of("p", "myAgent"));
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void validate_whenToolScopeElementIdReferencesSibling_returnsNoErrors() {
+        String bpmn = wrapInProcess("""
+                <adHocSubProcess id="myAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama" model="llama3.1"
+                                  toolScopeElementId="toolRegistry"/>
+                  </extensionElements>
+                </adHocSubProcess>
+                """);
+        Element config = parseConfigElement(bpmn);
+
+        List<String> errors = AgentConfigValidator.validate(config, "myAgent",
+                Set.of("p", "myAgent", "toolRegistry"));
+
+        assertTrue(errors.isEmpty());
+    }
+}

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/lifecycle/AgentConfigUndeployListenerTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/lifecycle/AgentConfigUndeployListenerTest.java
@@ -1,0 +1,32 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.lifecycle;
+
+import org.finos.fluxnova.bpm.engine.ProcessEngine;
+import org.finos.fluxnova.bpm.engine.ai.agent.registry.AgentConfigRegistry;
+import org.finos.fluxnova.bpm.spring.boot.starter.event.PreUndeployEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AgentConfigUndeployListenerTest {
+
+    @Mock
+    private AgentConfigRegistry registry;
+
+    @InjectMocks
+    private AgentConfigUndeployListener listener;
+
+    @Test
+    void onPreUndeploy_callsUnregisterAll() {
+        PreUndeployEvent event = new PreUndeployEvent(mock(ProcessEngine.class));
+
+        listener.onPreUndeploy(event);
+
+        verify(registry).unregisterAll();
+    }
+}

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListenerTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListenerTest.java
@@ -1,18 +1,16 @@
 package org.finos.fluxnova.bpm.engine.ai.agent.parser;
 
 import org.finos.fluxnova.bpm.engine.BpmnParseException;
-import org.finos.fluxnova.bpm.engine.shared.xml.BpmnXmlParser;
 import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
 import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.finos.fluxnova.bpm.engine.shared.xml.BpmnXmlParser;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AgentConfigParseListenerTest {
 
@@ -82,7 +80,7 @@ class AgentConfigParseListenerTest {
     }
 
     @Test
-    void parseRootElement_whenMultipleErrors_reportsAll() {
+    void parseRootElement_whenMultipleErrors_reportsAllInFirstElement() {
         String bpmn = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
@@ -105,11 +103,11 @@ class AgentConfigParseListenerTest {
         BpmnParseException ex = assertThrows(BpmnParseException.class,
                 () -> listener.parseRootElement(parseRoot(bpmn), List.of()));
         assertTrue(ex.getMessage().contains("agentA"), "expected agentA in message: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("agentB"), "expected agentB in message: " + ex.getMessage());
+        assertFalse(ex.getMessage().contains("agentB"), "expected agentB in message: " + ex.getMessage());
     }
 
     @Test
-    void parseRootElement_whenErrorsAcrossProcesses_reportsAll() {
+    void parseRootElement_whenErrorsAcrossProcesses_reportsAllInFirstElement() {
         String bpmn = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
@@ -134,7 +132,7 @@ class AgentConfigParseListenerTest {
         BpmnParseException ex = assertThrows(BpmnParseException.class,
                 () -> listener.parseRootElement(parseRoot(bpmn), List.of()));
         assertTrue(ex.getMessage().contains("agentP1"));
-        assertTrue(ex.getMessage().contains("agentP2"));
+        assertFalse(ex.getMessage().contains("agentP2"));
     }
 
 }

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListenerTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/parser/AgentConfigParseListenerTest.java
@@ -1,0 +1,140 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.parser;
+
+import org.finos.fluxnova.bpm.engine.BpmnParseException;
+import org.finos.fluxnova.bpm.engine.shared.xml.BpmnXmlParser;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentConfigParseListenerTest {
+
+    private final AgentConfigParseListener listener = new AgentConfigParseListener();
+
+    private Element parseRoot(String bpmn) {
+        BpmnXmlParser parser = new BpmnXmlParser();
+        Parse parse = parser.createParse()
+                .sourceInputStream(new ByteArrayInputStream(bpmn.getBytes(StandardCharsets.UTF_8)))
+                .execute();
+        return parse.getRootElement();
+    }
+
+    @Test
+    void parseRootElement_whenValidConfig_doesNotThrow() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="p">
+                    <adHocSubProcess id="myAgent">
+                      <extensionElements>
+                        <agent:config provider="ollama" model="llama3.1"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        assertDoesNotThrow(() -> listener.parseRootElement(parseRoot(bpmn), List.of()));
+    }
+
+    @Test
+    void parseRootElement_whenNoAgentConfig_doesNotThrow() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+                  <process id="p">
+                    <serviceTask id="t1"/>
+                  </process>
+                </definitions>
+                """;
+
+        assertDoesNotThrow(() -> listener.parseRootElement(parseRoot(bpmn), List.of()));
+    }
+
+    @Test
+    void parseRootElement_whenProviderMissing_throwsBpmnParseException() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="p">
+                    <adHocSubProcess id="myAgent">
+                      <extensionElements>
+                        <agent:config model="llama3.1"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        BpmnParseException ex = assertThrows(BpmnParseException.class,
+                () -> listener.parseRootElement(parseRoot(bpmn), List.of()));
+        assertTrue(ex.getMessage().contains("provider"));
+        assertTrue(ex.getMessage().contains("myAgent"));
+    }
+
+    @Test
+    void parseRootElement_whenMultipleErrors_reportsAll() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="p">
+                    <adHocSubProcess id="agentA">
+                      <extensionElements>
+                        <agent:config model="llama3.1"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                    <adHocSubProcess id="agentB">
+                      <extensionElements>
+                        <agent:config provider="ollama"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        BpmnParseException ex = assertThrows(BpmnParseException.class,
+                () -> listener.parseRootElement(parseRoot(bpmn), List.of()));
+        assertTrue(ex.getMessage().contains("agentA"), "expected agentA in message: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("agentB"), "expected agentB in message: " + ex.getMessage());
+    }
+
+    @Test
+    void parseRootElement_whenErrorsAcrossProcesses_reportsAll() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="p1">
+                    <adHocSubProcess id="agentP1">
+                      <extensionElements>
+                        <agent:config model="llama3.1"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                  <process id="p2">
+                    <adHocSubProcess id="agentP2">
+                      <extensionElements>
+                        <agent:config provider="ollama"/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        BpmnParseException ex = assertThrows(BpmnParseException.class,
+                () -> listener.parseRootElement(parseRoot(bpmn), List.of()));
+        assertTrue(ex.getMessage().contains("agentP1"));
+        assertTrue(ex.getMessage().contains("agentP2"));
+    }
+
+}

--- a/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/registry/AgentConfigRegistryTest.java
+++ b/backend/agentic/agent-config/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/registry/AgentConfigRegistryTest.java
@@ -1,0 +1,171 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.registry;
+
+import org.finos.fluxnova.bpm.engine.AuthorizationException;
+import org.finos.fluxnova.bpm.engine.RepositoryService;
+import org.finos.fluxnova.bpm.engine.ai.agent.extract.AgentConfigExtractor;
+import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AgentConfigRegistryTest {
+
+    private static final String PROC_DEF_ID = "creditCheck:1:abc";
+    private static final String ELEMENT_ID = "creditCheckAgent";
+
+    private static final String BPMN_WITH_AGENT = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                         xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+              <process id="creditCheck">
+                <adHocSubProcess id="creditCheckAgent">
+                  <extensionElements>
+                    <agent:config provider="ollama"
+                                  model="llama3.1"
+                                  systemPrompt="You are a credit analyst."/>
+                  </extensionElements>
+                </adHocSubProcess>
+              </process>
+            </definitions>
+            """;
+
+    private static final String BPMN_WITHOUT_AGENT = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+              <process id="plain">
+                <adHocSubProcess id="plainSub"/>
+              </process>
+            </definitions>
+            """;
+
+    @Mock
+    private RepositoryService repositoryService;
+
+    private AgentConfigRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new AgentConfigRegistry(repositoryService, new AgentConfigExtractor());
+    }
+
+    @Test
+    void resolve_whenProcessHasNoAgentConfig_returnsEmpty() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITHOUT_AGENT.getBytes(StandardCharsets.UTF_8)));
+
+        Optional<AgentConfig> result = registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void resolve_whenProcessHasAgentConfig_returnsConfig() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITH_AGENT.getBytes(StandardCharsets.UTF_8)));
+
+        Optional<AgentConfig> result = registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+
+        assertTrue(result.isPresent());
+        AgentConfig config = result.get();
+        assertEquals(PROC_DEF_ID, config.processDefinitionId());
+        assertEquals(ELEMENT_ID, config.elementId());
+        assertEquals("ollama", config.provider());
+        assertEquals("llama3.1", config.model());
+                assertEquals(ELEMENT_ID, config.toolScopeElementId());
+    }
+
+    @Test
+    void resolve_calledTwiceForSameDefinition_scansOnlyOnce() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITH_AGENT.getBytes(StandardCharsets.UTF_8)));
+
+        registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+        registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+
+        verify(repositoryService, times(1)).getProcessModel(PROC_DEF_ID);
+    }
+
+    @Test
+    void unregisterAll_clearsAllState() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITH_AGENT.getBytes(StandardCharsets.UTF_8)));
+
+        registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+        registry.unregisterAll();
+
+        // registry has been cleared — resolve returns empty without a second scan source
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITHOUT_AGENT.getBytes(StandardCharsets.UTF_8)));
+
+        Optional<AgentConfig> result = registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void resolve_afterUnregisterAll_rescansDefinition() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITH_AGENT.getBytes(StandardCharsets.UTF_8)));
+        registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+
+        registry.unregisterAll();
+
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITH_AGENT.getBytes(StandardCharsets.UTF_8)));
+        registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+
+        verify(repositoryService, times(2)).getProcessModel(PROC_DEF_ID);
+    }
+
+    @Test
+    void resolve_whenScanThrows_doesNotMarkAsPermanentlyScanned() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenThrow(new RuntimeException("DB blip"))
+                .thenReturn(new ByteArrayInputStream(BPMN_WITH_AGENT.getBytes(StandardCharsets.UTF_8)));
+
+        // First call fails — exception propagates
+        assertThrows(RuntimeException.class, () -> registry.resolve(PROC_DEF_ID, ELEMENT_ID));
+
+        // Second call should retry and succeed (not permanently marked as scanned)
+        Optional<AgentConfig> second = registry.resolve(PROC_DEF_ID, ELEMENT_ID);
+        assertTrue(second.isPresent());
+        assertEquals("ollama", second.get().provider());
+
+        verify(repositoryService, times(2)).getProcessModel(PROC_DEF_ID);
+    }
+
+    @Test
+    void resolve_whenScanThrowsNotFoundException_propagates() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenThrow(new NotFoundException("not found"));
+
+        assertThrows(NotFoundException.class, () -> registry.resolve(PROC_DEF_ID, ELEMENT_ID));
+    }
+
+    @Test
+    void resolve_whenScanThrowsAuthorizationException_propagates() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenThrow(new AuthorizationException("forbidden"));
+
+        assertThrows(AuthorizationException.class, () -> registry.resolve(PROC_DEF_ID, ELEMENT_ID));
+    }
+
+    @Test
+    void resolve_whenScanThrowsUnchecked_propagatesException() throws Exception {
+        when(repositoryService.getProcessModel(PROC_DEF_ID))
+                .thenThrow(new RuntimeException("unexpected"));
+
+        assertThrows(RuntimeException.class, () -> registry.resolve(PROC_DEF_ID, ELEMENT_ID));
+    }
+
+}

--- a/backend/agentic/pom.xml
+++ b/backend/agentic/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.finos.fluxnova.bpm</groupId>
+    <artifactId>fluxnova-plugins</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>fluxnova-engine-plugins-ai-agentic</artifactId>
+  <packaging>pom</packaging>
+  <name>Fluxnova Platform - engine plugins - agentic</name>
+  <modules>
+    <module>../shared</module>
+    <module>agent-config</module>
+  </modules>
+</project>

--- a/backend/shared/pom.xml
+++ b/backend/shared/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.finos.fluxnova.bpm</groupId>
+    <artifactId>fluxnova-plugins</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>fluxnova-engine-plugins-shared</artifactId>
+  <packaging>jar</packaging>
+  <name>Fluxnova Platform - engine plugins - shared</name>
+  <description>Shared support classes for Fluxnova engine plugins</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.finos.fluxnova.bpm</groupId>
+      <artifactId>fluxnova-engine</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/backend/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/agent/AgentModelConstants.java
+++ b/backend/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/agent/AgentModelConstants.java
@@ -1,0 +1,11 @@
+package org.finos.fluxnova.bpm.engine.shared.agent;
+
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Namespace;
+
+public final class AgentModelConstants {
+
+    public static final Namespace AGENT_NS = new Namespace("http://fluxnova.finos.org/schema/1.0/ai/agent");
+
+    private AgentModelConstants() {
+    }
+}

--- a/backend/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/xml/BpmnXmlParse.java
+++ b/backend/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/xml/BpmnXmlParse.java
@@ -1,0 +1,11 @@
+package org.finos.fluxnova.bpm.engine.shared.xml;
+
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parser;
+
+class BpmnXmlParse extends Parse {
+
+    BpmnXmlParse(Parser parser) {
+        super(parser);
+    }
+}

--- a/backend/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/xml/BpmnXmlParser.java
+++ b/backend/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/xml/BpmnXmlParser.java
@@ -1,0 +1,25 @@
+package org.finos.fluxnova.bpm.engine.shared.xml;
+
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parser;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+public class BpmnXmlParser extends Parser {
+
+    @Override
+    public Parse createParse() {
+        return new BpmnXmlParse(this);
+    }
+
+    @Override
+    protected SAXParser getSaxParser() throws ParserConfigurationException, SAXException {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        setXxeProcessing(factory);
+        return factory.newSAXParser();
+    }
+}

--- a/backend/shared/src/test/java/org/finos/fluxnova/bpm/engine/shared/xml/BpmnXmlParserTest.java
+++ b/backend/shared/src/test/java/org/finos/fluxnova/bpm/engine/shared/xml/BpmnXmlParserTest.java
@@ -1,0 +1,70 @@
+package org.finos.fluxnova.bpm.engine.shared.xml;
+
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Element;
+import org.finos.fluxnova.bpm.engine.impl.util.xml.Parse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BpmnXmlParserTest {
+
+    private static final String MINIMAL_BPMN = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+              <process id="testProcess"/>
+            </definitions>
+            """;
+
+    private static final String BPMN_WITH_DOCTYPE = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE definitions [
+                <!ELEMENT definitions ANY >
+            ]>
+            <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+                <process id="testProcess"/>
+            </definitions>
+            """;
+
+    @Test
+    void parse_returnsRootElementWithCorrectTagName() {
+        BpmnXmlParser parser = new BpmnXmlParser();
+        Parse parse = parser.createParse()
+                .sourceInputStream(new ByteArrayInputStream(MINIMAL_BPMN.getBytes(StandardCharsets.UTF_8)))
+                .execute();
+
+        Element root = parse.getRootElement();
+
+        assertNotNull(root);
+        assertEquals("definitions", root.getTagName());
+    }
+
+    @Test
+    void parse_navigatesToChildElement() {
+        BpmnXmlParser parser = new BpmnXmlParser();
+        Parse parse = parser.createParse()
+                .sourceInputStream(new ByteArrayInputStream(MINIMAL_BPMN.getBytes(StandardCharsets.UTF_8)))
+                .execute();
+
+        Element process = parse.getRootElement().element("process");
+
+        assertNotNull(process);
+        assertEquals("testProcess", process.attribute("id"));
+    }
+
+    @Test
+    void parse_rejectsDoctypeDeclarations() {
+        BpmnXmlParser parser = new BpmnXmlParser();
+
+        Exception thrown = assertThrows(Exception.class, () -> parser.createParse()
+                .sourceInputStream(new ByteArrayInputStream(BPMN_WITH_DOCTYPE.getBytes(StandardCharsets.UTF_8)))
+                .execute());
+
+        assertTrue(thrown.getMessage().contains("DOCTYPE is disallowed"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.finos.fluxnova.bpm</groupId>
+  <artifactId>fluxnova-plugins</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>Fluxnova Platform - engine plugins</name>
+  <modules>
+    <module>backend/shared</module>
+    <module>backend/agentic</module>
+  </modules>
+  <properties>
+    <fluxnova.version>2.0.0-SNAPSHOT</fluxnova.version>
+    <maven.compiler.release>21</maven.compiler.release>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.finos.fluxnova.bpm</groupId>
+        <artifactId>fluxnova-bom</artifactId>
+        <version>${fluxnova.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>3.5.8</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>


### PR DESCRIPTION
## Summary

This PR implements **Component 1 – Agent Configuration** of the [5-component agentic AI server-side architecture](https://github.com/finos/fluxnova-ai/discussions/17). This component holds canonical agent configuration (provider/model, prompts, context bindings, tool-scope reference) and, given a process definition and element at runtime, returns a resolved `AgentConfig` object for use by the other components (Tool & Context Discovery, LLM Invocation, Tool Invocation Driver, and the Feedback Loop). You can find a more detailed description of the 5 component architecture for an ad-hoc subprocess based implementation in [this comment](https://github.com/finos/fluxnova-ai/discussions/17#discussioncomment-16681513).

All proposals (1–5) depend on this component as a shared foundation. Configuration is authored via BPMN extension elements on any BPMN element (not limited to ad-hoc subprocesses), validated at deploy time, cached at runtime, and invalidated on undeployment.

Relates to: [finos/fluxnova-ai#25](https://github.com/finos/fluxnova-ai/issues/25)

---

## Module External API

### `AgentConfig` (record)

Immutable value object representing a resolved agent configuration. Fields:

| Field | Description |
|-------|-------------|
| `processDefinitionId` | Process definition owning the configured element |
| `elementId` | BPMN element carrying the agent configuration |
| `provider` | AI provider identifier (e.g. `"ollama"`, `"openai"`) |
| `model` | Model identifier within the provider (e.g. `"llama3"`) |
| `systemPrompt` | System prompt text (nullable) |
| `toolScopeElementId` | BPMN element defining tool-resolution scope; defaults to `elementId` |

### `AgentConfigRegistry` (service)

Central lookup API for other components to consume:

- `Optional<AgentConfig> resolve(String processDefinitionId, String elementId)` – resolves and caches the agent config for a given BPMN element.
- `void unregisterAll()` – clears all cached configs (called on undeployment).

Uses a two-level `ConcurrentHashMap` cache with lazy loading via `RepositoryService`.

---

## Internal Classes

| Class | Purpose |
|-------|---------|
| `AgentConfigExtractor` | Parses `<agent:config>` extension elements from BPMN XML into `AgentConfig` records |
| `AgentConfigElementWalker` | Depth-first recursive traversal of BPMN XML elements (skips `extensionElements` branches) |
| `AgentConfigValidator` | Validates required attributes (`provider`, `model`) and referential integrity of `toolScopeElementId` |
| `AgentConfigParseListener` | BPMN parse listener that validates all agent configs at deploy time; rejects invalid deployments with `BpmnParseException` |
| `AgentConfigUndeployListener` | Spring `@EventListener` on `PreUndeployEvent` that clears the registry cache |
| `AgentConfigAutoConfiguration` | Spring Boot auto-configuration registering all beans; conditional on `RepositoryService` presence |
| `AgentConfigEnginePlugin` | Process engine plugin that registers `AgentConfigParseListener` as a post-parse listener |
