### PR TITLE
Initial commit: Fluxnova script backward compatibility plugin

### DIFF
--- a/fluxnova-backward-compatibility-plugin/README.md
+++ b/fluxnova-backward-compatibility-plugin/README.md
@@ -1,0 +1,148 @@
+# Fluxnova Backward Compatibility Plugin
+
+A Fluxnova Backward Compatibility plugin for the Fluxnova process engine that provides seamless backward compatibility by rewriting Camunda package references to Fluxnova equivalents at runtime during script execution.
+
+---
+
+## Key Features
+
+- **Automated Migration**: Transparently rewrites Camunda references in scripts to Fluxnova equivalents.
+- **Dual-Mode Operation**: Supports both Spring Boot auto-configuration and plain Java (non-Spring) environments.
+- **Flexible Configuration**: Hierarchical property resolution (Spring, JVM, classpath, built-in defaults).
+- **Fail-Open Safety**: Always returns the original script if any error occurs during processing.
+- **Defensive Copying**: Prevents external mutation of preprocessor lists.
+- **Chaining Support**: Multiple preprocessors and plugins can be safely combined.
+- **Robust Null Handling**: Handles null configuration and script values gracefully.
+
+---
+
+## Overview
+
+Implements the `ProcessEnginePlugin` interface and registers one or more `ScriptPreprocessor` instances to perform automated migration of script code by replacing:
+
+- `org.camunda.*` → `org.finos.fluxnova.*` (root package)
+- `.camunda.` → `.fluxnova.` (package path, configurable)
+- `*Camunda*` → `*Fluxnova*` (class names, configurable, **off by default**)
+
+---
+
+## Configuration
+
+### Property Hierarchy
+
+1. **Spring environment properties** (if running under Spring Boot)
+2. **JVM system properties**
+3. **Classpath property file** (`script-preprocessor.properties`)
+4. **Built-in defaults**
+
+### Example `script-preprocessor.properties`
+
+```properties
+# Enable/disable the plugin (default: true)
+fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin=true
+
+# Enable default Camunda-to-Fluxnova rewrite preprocessor (default: true)
+fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled=true
+
+# Rewrite org.camunda → org.finos.fluxnova (default: true)
+fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInRootPackage=true
+
+# Rewrite .camunda. → .fluxnova. (default: false)
+fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInPackagePath=false
+
+# Rewrite Camunda → Fluxnova in class names (default: false)
+fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName=false
+```
+
+> **Note:** Class name rewriting is **off by default**. Enable it by setting the property to `true`.
+
+### Overriding Properties
+
+- **JVM**: `-Dfluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName=true`
+- **Spring**: Set in `application.properties` or `application.yml` as shown in the previous section.
+
+---
+
+## Usage
+
+### Spring Boot (Auto-configuration)
+
+No explicit configuration is required. The plugin is auto-registered if Spring Boot is present.
+
+### Spring XML
+
+Register the plugin and preprocessors as beans in your XML configuration.
+
+### Plain Java
+
+```java
+ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+plugin.setScriptPreprocessors(List.of(new CamundaToFluxnovaRewritePreprocessor()));
+config.getProcessEnginePlugins().add(plugin);
+```
+
+---
+
+## Example Transformation
+
+**Input:**
+```javascript
+var engine = org.camunda.bpm.engine.ProcessEngineProvider.getDefaultProcessEngine();
+var task = new org.camunda.bpm.engine.task.TaskQuery();
+```
+
+**Output (all rewrites enabled):**
+```javascript
+var engine = org.finos.fluxnova.bpm.engine.ProcessEngineProvider.getDefaultProcessEngine();
+var task = new org.finos.fluxnova.bpm.engine.task.TaskQuery();
+```
+
+---
+
+## Preprocessor Chaining & Safety
+
+- Multiple preprocessors can be registered per plugin; order is preserved.
+- Multiple plugins append their preprocessors to the engine's chain.
+- If any preprocessor fails, the original script is returned and processing continues.
+
+---
+
+## Architecture
+
+| Class                                   | Purpose                                                      |
+|-----------------------------------------|--------------------------------------------------------------|
+| `ScriptPreprocessorPlugin`              | Registers preprocessors with the engine                      |
+| `CamundaToFluxnovaRewritePreprocessor`  | Regex-based rewrite logic; robust fail-open and null-safety  |
+| `ScriptingConfigurationProperties`      | Loads and resolves all configuration properties              |
+| `ScriptPreprocessorAutoConfiguration`   | Spring Boot auto-configuration                              |
+| `ScriptPreprocessorProperties`          | Spring-specific property binding                             |
+
+---
+
+## Logging & Observability
+
+- **DEBUG**: Rewrite statistics (root/package/class replacements)
+- **WARN**: Missing config file or invalid property values
+- **ERROR**: Processing errors (fail-open)
+
+---
+
+## Build & Compatibility
+
+- **Java**: 21+
+- **Spring Boot**: 4.0.5
+- **Fluxnova Engine**: 3.0.0-SNAPSHOT
+- **Build**: `mvn clean package`
+- **Output**: `target/fluxnova-backward-compatibility-plugin-1.0.0-SNAPSHOT.jar`
+
+---
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+---
+
+## Contributing
+
+Please submit issues and pull requests to the [FINOS Fluxnova project](https://github.com/orgs/finos/projects/116).

--- a/fluxnova-backward-compatibility-plugin/pom.xml
+++ b/fluxnova-backward-compatibility-plugin/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.finos.fluxnova.plugins</groupId>
+  <artifactId>fluxnova-backward-compatibility-plugin</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <packaging>jar</packaging>
+
+  <name>Fluxnova Backward Compatibility Script Preprocessor Plugin</name>
+  <description>A script preprocessor plugin for the Fluxnova BPM Platform. Provides backward
+    compatibility by rewriting Camunda API references to Fluxnova equivalents at script
+    execution time, without requiring changes to the original scripts.</description>
+
+  <properties>
+    <fluxnova.version>3.0.0-SNAPSHOT</fluxnova.version>
+    <java.version>21</java.version>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spring.boot.version>4.0.5</spring.boot.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <apache.commons.version>3.20.0</apache.commons.version>
+    <skipTests>false</skipTests>
+    <skipITs>false</skipITs>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Fluxnova Engine -->
+    <dependency>
+      <groupId>org.finos.fluxnova.bpm</groupId>
+      <artifactId>fluxnova-engine</artifactId>
+      <version>${fluxnova.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${apache.commons.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- use logback as logger -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.15.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.5</version>
+        <configuration>
+          <skipTests>${skipTests}</skipTests>
+          <excludes>
+            <exclude>**/*IT.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.5.5</version>
+        <configuration>
+          <skipITs>${skipITs}</skipITs>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>ossrh-snapshots</id>
+      <name>Sonatype OSSRH Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <issueManagement>
+    <system>Jira</system>
+    <url>https://github.com/orgs/finos/projects/116</url>
+  </issueManagement>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <name>Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+</project>

--- a/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/ScriptPreprocessorPlugin.java
+++ b/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/ScriptPreprocessorPlugin.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.finos.fluxnova.bpm.engine.ProcessEngine;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor;
+import org.finos.fluxnova.plugin.preprocessor.core.ScriptingConfigurationProperties;
+
+/**
+ * A {@link ProcessEnginePlugin} that registers one or more {@link ScriptPreprocessor}s with the
+ * Fluxnova process engine at startup.
+ *
+ * <p>Preprocessors are appended to any preprocessors already configured on the engine, so multiple
+ * plugins can co-exist without overwriting each other's contributions.
+ *
+ * <p><strong>Configuration:</strong>
+ *
+ * <p>Behavior is controlled by properties in {@code script-preprocessor.properties}:
+ * <ul>
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin} - master gate; if
+ *       {@code false}, plugin returns immediately.</li>
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled}
+ *       - enables registration of the default Camunda-to-Fluxnova preprocessor instance.</li>
+ *   <li>Additional rewrite flags control behavior of the default preprocessor.</li>
+ * </ul>
+ *
+ * <p>Properties can be overridden via JVM system properties or Spring environment properties.
+ *
+ * <p><strong>Usage (bpm.cfg.xml / programmatic):</strong>
+ *
+ * <pre>
+ * ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+ * plugin.setScriptPreprocessors(List.of(new CamundaToFluxnovaRewritePreprocessor()));
+ * config.getProcessEnginePlugins().add(plugin);
+ * </pre>
+ *
+ * @since 1.0.0
+ */
+public class ScriptPreprocessorPlugin implements ProcessEnginePlugin {
+
+  /** The list of script preprocessors to register with the engine. May be {@code null}. */
+  private List<ScriptPreprocessor> scriptPreprocessors;
+
+  private Boolean enableDefaultCamundaToFluxnovaPreprocessor;
+
+  /**
+   * Registers the configured {@link ScriptPreprocessor}s with the engine before initialization.
+   *
+   * <p>Checks the master property
+   * {@code fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin}; if disabled, returns
+   * immediately. Then evaluates the default-preprocessor flag and any user-provided
+   * preprocessors, and registers the resulting chain with the engine.
+   *
+   * @param config the engine configuration being initialized
+   */
+  @Override
+  public void preInit(ProcessEngineConfigurationImpl config) {
+    ScriptingConfigurationProperties properties = new ScriptingConfigurationProperties();
+    if (!properties.isEnableEnginePlugin()) {
+      return;
+    }
+    boolean enableDefaultPreprocessor =
+        enableDefaultCamundaToFluxnovaPreprocessor != null
+            ? enableDefaultCamundaToFluxnovaPreprocessor
+            : properties.isDefaultCamundaToFluxnovaPreprocessorEnabled();
+
+    List<ScriptPreprocessor> allPreprocessors = new ArrayList<>();
+    if (enableDefaultPreprocessor) {
+      allPreprocessors.add(new CamundaToFluxnovaRewritePreprocessor());
+    }
+    if (scriptPreprocessors != null && !scriptPreprocessors.isEmpty()) {
+      allPreprocessors.addAll(scriptPreprocessors);
+    }
+    if (allPreprocessors.isEmpty()) {
+      return;
+    }
+    config.setEnableScriptPreprocessing(true);
+    List<ScriptPreprocessor> existingPreprocessors = config.getScriptPreprocessors();
+    if (existingPreprocessors == null || existingPreprocessors.isEmpty()) {
+      config.setScriptPreprocessors(allPreprocessors);
+    } else {
+      existingPreprocessors.addAll(allPreprocessors);
+    }
+  }
+
+  /**
+   * Called after engine initialisation. No action required for this plugin.
+   *
+   * @param config the engine configuration after initialisation
+   */
+  @Override
+  public void postInit(ProcessEngineConfigurationImpl config) {
+    // no-op
+  }
+
+  /**
+   * Called after the process engine has been built. No action required for this plugin.
+   *
+   * @param processEngine the fully built process engine
+   */
+  @Override
+  public void postProcessEngineBuild(ProcessEngine processEngine) {
+    // no-op
+  }
+
+  /**
+   * Sets the {@link ScriptPreprocessor}s to register with the engine.
+   *
+   * @param scriptPreprocessors the preprocessors to register; may be {@code null} or empty
+   */
+  public void setScriptPreprocessors(List<ScriptPreprocessor> scriptPreprocessors) {
+    this.scriptPreprocessors =
+        scriptPreprocessors != null ? new ArrayList<>(scriptPreprocessors) : null;
+  }
+
+  /**
+   * Overrides the default-preprocessor toggle for this plugin instance.
+   *
+   * <p>When set, this value takes precedence over
+   * {@code fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled}
+   * loaded from properties.
+   *
+   * @param enable whether to register the default Camunda-to-Fluxnova preprocessor
+   */
+  public void setEnableDefaultCamundaToFluxnovaPreprocessor(boolean enable) {
+    this.enableDefaultCamundaToFluxnovaPreprocessor = enable;
+  }
+
+}

--- a/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/core/CamundaToFluxnovaRewritePreprocessor.java
+++ b/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/core/CamundaToFluxnovaRewritePreprocessor.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.core;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Script preprocessor that rewrites Camunda package references to Fluxnova equivalents.
+ *
+ * <p>This preprocessor should be enabled only after migration readiness has been confirmed.
+ *
+ * <p>This preprocessor performs automated migration of script code by replacing:
+ *
+ * <ul>
+ *   <li>Package names: {@code org.camunda.*} → {@code org.finos.fluxnova.*}
+ *   <li>Package path segments: {@code .camunda.} → {@code .fluxnova.} (configurable)
+ *   <li>Class names containing {@code Camunda}: {@code *Camunda*} → {@code *Fluxnova*}
+ *       (configurable)
+ * </ul>
+ *
+ * <p><strong>Example transformation:</strong>
+ *
+ * <pre>
+ * // Input:
+ * import org.camunda.bpm.engine.ProcessEngine;
+ *
+ * // Output:
+ * import org.finos.fluxnova.bpm.engine.ProcessEngine;
+ * </pre>
+ *
+ * <p>The preprocessor behaviour is controlled via {@code script-preprocessor.properties}:
+ *
+ * <ul>
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInRootPackage} – Controls root package replacement
+ *       ({@code org.camunda} → {@code org.finos.fluxnova})
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInPackagePath} – Controls secondary package segment
+ *       replacement ({@code .camunda.} → {@code .fluxnova.})
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName} – Controls class name substring replacement
+ *       ({@code Camunda} → {@code Fluxnova})
+ * </ul>
+ *
+ * @see ScriptingConfigurationProperties
+ * @since 1.0.0
+ */
+public class CamundaToFluxnovaRewritePreprocessor implements ScriptPreprocessor {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(CamundaToFluxnovaRewritePreprocessor.class);
+
+  private final ScriptingConfigurationProperties config;
+
+  /**
+   * Creates a preprocessor using configuration loaded from {@code script-preprocessor.properties}
+   * on the classpath.
+   */
+  public CamundaToFluxnovaRewritePreprocessor() {
+    this(new ScriptingConfigurationProperties());
+  }
+
+  /**
+   * Creates a preprocessor with an explicit configuration (useful for testing).
+   *
+   * <p>If {@code config} is {@code null}, the preprocessor falls back to a configuration loaded
+   * from {@code script-preprocessor.properties}.
+   *
+   * @param config the configuration to use; may be {@code null}
+   */
+  public CamundaToFluxnovaRewritePreprocessor(ScriptingConfigurationProperties config) {
+    if (config == null) {
+      log.warn(
+          "{} : Received null configuration, falling back to classpath defaults.",
+          getClass().getSimpleName());
+      this.config = new ScriptingConfigurationProperties();
+      return;
+    }
+    this.config = config;
+  }
+
+  /**
+   * Regex pattern for matching Camunda package references.
+   *
+   * <p>Pattern breakdown:
+   *
+   * <ul>
+   *   <li>{@code (^|[^A-Za-z0-9_])} - Word boundary (start of line or non-identifier character)
+   *   <li>{@code org\.camunda} - Root package literal
+   *   <li>{@code (?=\.|[^A-Za-z0-9_]|$)} - Lookahead for package separator, boundary, or end
+   *   <li>{@code (?:\.[a-z_][a-z0-9_]*)*} - Optional lowercase package segments
+   *   <li>{@code (?:\.[A-Z][A-Za-z0-9_]*)?} - Optional class name (starts with uppercase)
+   * </ul>
+   */
+  private static final Pattern ROOT_PACKAGE_PATTERN =
+      Pattern.compile(
+          "(^|[^A-Za-z0-9_])(org\\.camunda(?=\\.|[^A-Za-z0-9_]|$)(?:\\.[a-z_][a-z0-9_]*)*(?:\\.[A-Z][A-Za-z0-9_]*)?)");
+
+  /** Package path segment to replace (old). */
+  private static final String SECONDARY_PACKAGE_PATTERN_OLD = ".camunda";
+
+  /** Package path segment replacement (new). */
+  private static final String SECONDARY_PACKAGE_PATTERN_NEW = ".fluxnova";
+
+  /** Part of the class name to replace (old). */
+  private static final String OLD_CLASS_NAME = "Camunda";
+
+  /** Part of the class name to replace (new). */
+  private static final String NEW_CLASS_NAME = "Fluxnova";
+
+  /**
+   * Processes the script by rewriting Camunda package and class references to Fluxnova.
+   *
+   * @param request the preprocessing request containing the script to process; may be {@code null}
+   * @return the processed script with rewritten package references, or the original if request/script is null/empty
+   */
+  @Override
+  public String process(ScriptPreprocessorRequest request) {
+    if (request == null) {
+      log.debug("{} : Request is null, skipping preprocessing.", getName());
+      return null;
+    }
+    String script = request.getScript();
+    if (script == null || script.isEmpty()) {
+      log.debug("{} : Script is null or empty, skipping preprocessing.", getName());
+      return script;
+    }
+    if (!script.contains("org.camunda")) {
+      log.debug("{} : No Camunda references found, skipping preprocessing.", getName());
+      return script;
+    }
+    log.debug("{} : STARTING SCRIPT PREPROCESSING", getName());
+    try {
+      return replacePackage(script);
+    } catch (Exception e) {
+      log.error("{} : Error during script preprocessing, returning original script.", getName(), e);
+      return script;
+    }
+  }
+
+  /**
+   * Returns the unique name of this preprocessor.
+   *
+   * @return the preprocessor name
+   */
+  @Override
+  public String getName() {
+    return "CamundaToFluxnovaRewritePreprocessor";
+  }
+
+  /**
+   * Replaces all Camunda package references in the script with Fluxnova equivalents.
+   *
+   * <p>This method:
+   *
+   * <ol>
+   *   <li>Matches all fully-qualified Camunda package references
+   *   <li>Optionally rewrites the root package from {@code org.camunda} to
+   *       {@code org.finos.fluxnova} (if configured)
+   *   <li>Optionally replaces secondary package segments in path (if configured)
+   *   <li>Optionally replaces class name prefixes (if configured)
+   *   <li>Preserves surrounding context and word boundaries
+   * </ol>
+   *
+   * @param script the original script content
+   * @return the script with replaced package and class references
+   */
+  protected String replacePackage(String script) {
+    Matcher matcher = ROOT_PACKAGE_PATTERN.matcher(script);
+    StringBuilder result = new StringBuilder();
+    CamundaToFluxnovaRewriteStats stats = new CamundaToFluxnovaRewriteStats();
+    while (matcher.find()) {
+      String boundary = matcher.group(1);
+      String rewritten = matcher.group(2);
+      if (config.isRewriteCamundaReferencesInPackageRoot()) {
+        rewritten = rewritten.replaceFirst("^org\\.camunda", "org.finos.fluxnova");
+        stats.incrementRootPackageReplacements(1);
+      }
+      if (config.isRewriteCamundaReferencesInPackagePath()
+          && rewritten.contains(SECONDARY_PACKAGE_PATTERN_OLD)) {
+        int count = StringUtils.countMatches(rewritten, SECONDARY_PACKAGE_PATTERN_OLD);
+        rewritten = rewritten.replace(SECONDARY_PACKAGE_PATTERN_OLD, SECONDARY_PACKAGE_PATTERN_NEW);
+        stats.incrementPackagePathReplacements(count);
+      }
+      if (config.isRewriteCamundaReferencesInClassName()) {
+        rewritten = replaceClassNames(rewritten, stats);
+      }
+      matcher.appendReplacement(result, Matcher.quoteReplacement(boundary + rewritten));
+    }
+    matcher.appendTail(result);
+    stats.logStats(this.getName());
+    return result.toString();
+  }
+
+  /**
+   * Replaces occurrences of {@code Camunda} in class names with {@code Fluxnova}.
+   *
+   * <p>Only replaces within the class name if:
+   *
+   * <ul>
+   *   <li>The fully-qualified name contains a class name (segment after last dot)
+   *   <li>The class name starts with an uppercase letter (follows Java naming conventions)
+   *   <li>Contains the "Camunda" substring
+   * </ul>
+   *
+   * <p><strong>Examples:</strong>
+   *
+   * <ul>
+   *   <li>{@code org.finos.fluxnova.CamundaTask} → {@code org.finos.fluxnova.FluxnovaTask}
+   *   <li>{@code org.finos.fluxnova.MyCamundaHelper} → {@code org.finos.fluxnova.MyFluxnovaHelper}
+   *   <li>{@code org.finos.fluxnova.TaskCamundaProcessor} → {@code
+   *       org.finos.fluxnova.TaskFluxnovaProcessor}
+   * </ul>
+   *
+   * @param fullyQualifiedName the fully-qualified class name to process
+   * @return the fully-qualified name with all "Camunda" occurrences replaced in the class name , or
+   *     original if no class name present
+   */
+  private String replaceClassNames(String fullyQualifiedName, CamundaToFluxnovaRewriteStats stats) {
+    int lastDotIndex = fullyQualifiedName.lastIndexOf('.');
+    if (lastDotIndex == -1) {
+      return fullyQualifiedName; // No class name segment; return as-is.
+    }
+    String packageName = fullyQualifiedName.substring(0, lastDotIndex + 1);
+    String className = fullyQualifiedName.substring(lastDotIndex + 1);
+    if (!className.isEmpty()
+        && className.contains(OLD_CLASS_NAME)
+        && Character.isUpperCase(className.charAt(0))) {
+      int count = StringUtils.countMatches(className, OLD_CLASS_NAME);
+      className = className.replace(OLD_CLASS_NAME, NEW_CLASS_NAME);
+      stats.incrementClassNameReplacements(count);
+    }
+    return packageName + className;
+  }
+
+  private static final class CamundaToFluxnovaRewriteStats {
+    private int rootPackageReplacements;
+    private int packagePathReplacements;
+    private int classNameReplacements;
+
+    void incrementRootPackageReplacements(int count) {
+      this.rootPackageReplacements = rootPackageReplacements + count;
+    }
+
+    void incrementPackagePathReplacements(int count) {
+      this.packagePathReplacements = packagePathReplacements + count;
+    }
+
+    void incrementClassNameReplacements(int count) {
+      this.classNameReplacements = classNameReplacements + count;
+    }
+
+    void logStats(String preprocessorName) {
+      log.debug(
+          "{} : Preprocessing complete – rootPackageReplacements={}, packagePathReplacements={}, classNameReplacements={}.",
+          preprocessorName,
+          this.rootPackageReplacements,
+          this.packagePathReplacements,
+          this.classNameReplacements);
+    }
+  }
+}

--- a/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/core/ScriptingConfigurationProperties.java
+++ b/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/core/ScriptingConfigurationProperties.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Plain-Java configuration holder for the Script Preprocessor Plugin.
+ *
+ * <p>Properties are loaded from {@code script-preprocessor.properties} on the classpath.
+ * Each property can be overridden at runtime via a Java system property with the same key.
+ *
+ * <p><strong>Supported properties:</strong>
+ *
+ * <ul>
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin}
+ *       (default: {@code true})
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled}
+ *       (default: {@code true})
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInRootPackage}
+ *       (default: {@code true})
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInPackagePath}
+ *       (default: {@code false})
+ *   <li>{@code fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName}
+ *       (default: {@code false})
+ * </ul>
+ *
+ * <p>The legacy unprefixed keys are also accepted as a fallback for non-Spring/manual usage.
+ *
+ * <p>Boolean values must be {@code true} or {@code false} (case-insensitive). Any other non-null
+ * value (for example, {@code yes}) is treated as {@code false} to match
+ * {@link Boolean#parseBoolean(String)} semantics, and a warning is logged.
+ *
+ * @since 1.0.0
+ */
+public final class ScriptingConfigurationProperties {
+
+  private static final Logger log = LoggerFactory.getLogger(ScriptingConfigurationProperties.class);
+
+  private static final String PROPERTIES_FILE = "script-preprocessor.properties";
+
+  private static final String PREFIX = "fluxnova.bpm.plugin.script-preprocessing.";
+
+  private static final String KEY_REWRITE_PACKAGE_ROOT =
+      "rewriteCamundaReferencesInRootPackage";
+  private static final String KEY_REWRITE_PACKAGE_PATH =
+      "rewriteCamundaReferencesInPackagePath";
+  private static final String KEY_REWRITE_CLASS_NAME =
+      "rewriteCamundaReferencesInClassName";
+  private static final String KEY_ENABLE_ENGINE_PLUGIN = "enableEnginePlugin";
+  private static final String KEY_ENABLE_CAM_FXN_REWRITE_PLUGIN =
+      "defaultCamundaToFluxnovaPreprocessorEnabled";
+
+  private static final String PREFIXED_KEY_ENABLE_ENGINE_PLUGIN = PREFIX + KEY_ENABLE_ENGINE_PLUGIN;
+  private static final String PREFIXED_KEY_REWRITE_PACKAGE_ROOT = PREFIX + KEY_REWRITE_PACKAGE_ROOT;
+  private static final String PREFIXED_KEY_REWRITE_PACKAGE_PATH = PREFIX + KEY_REWRITE_PACKAGE_PATH;
+  private static final String PREFIXED_KEY_REWRITE_CLASS_NAME = PREFIX + KEY_REWRITE_CLASS_NAME;
+  private static final String PREFIXED_KEY_ENABLE_CAM_FXN_REWRITE_PLUGIN =
+      PREFIX + KEY_ENABLE_CAM_FXN_REWRITE_PLUGIN;
+
+  private final boolean enableEnginePlugin;
+  private final boolean rewriteCamundaReferencesInPackageRoot;
+  private final boolean rewriteCamundaReferencesInPackagePath;
+  private final boolean rewriteCamundaReferencesInClassName;
+  private final boolean defaultCamundaToFluxnovaPreprocessorEnabled;
+
+  /**
+   * Creates an instance by loading configuration from {@code script-preprocessor.properties} on
+   * the classpath. System properties take precedence over file-based values.
+   */
+  public ScriptingConfigurationProperties() {
+    Properties props = loadProperties();
+    this.enableEnginePlugin =
+        resolveBoolean(props, PREFIXED_KEY_ENABLE_ENGINE_PLUGIN, KEY_ENABLE_ENGINE_PLUGIN, true);
+    this.rewriteCamundaReferencesInPackageRoot =
+        resolveBoolean(
+            props, PREFIXED_KEY_REWRITE_PACKAGE_ROOT, KEY_REWRITE_PACKAGE_ROOT, true);
+    this.rewriteCamundaReferencesInPackagePath =
+        resolveBoolean(
+            props, PREFIXED_KEY_REWRITE_PACKAGE_PATH, KEY_REWRITE_PACKAGE_PATH, false);
+    this.rewriteCamundaReferencesInClassName =
+        resolveBoolean(
+            props, PREFIXED_KEY_REWRITE_CLASS_NAME, KEY_REWRITE_CLASS_NAME, false);
+    this.defaultCamundaToFluxnovaPreprocessorEnabled =
+        resolveBoolean(props, PREFIXED_KEY_ENABLE_CAM_FXN_REWRITE_PLUGIN,
+            KEY_ENABLE_CAM_FXN_REWRITE_PLUGIN, true);
+
+    log.debug(
+        "ScriptingConfigurationProperties loaded: enableEnginePlugin={}, rewritePackageRoot={}, rewritePackagePath={}, rewriteClassName={}, camundaToFluxnovaPreprocessorEnabled={}",
+        this.enableEnginePlugin,
+        this.rewriteCamundaReferencesInPackageRoot,
+        this.rewriteCamundaReferencesInPackagePath,
+        this.rewriteCamundaReferencesInClassName,
+        this.defaultCamundaToFluxnovaPreprocessorEnabled);
+  }
+
+  /**
+   * Creates an instance with explicit configuration values.
+   *
+   * <p>Useful for testing or programmatic configuration. Spring auto-configuration also uses this
+   * constructor to create instances from bound properties.
+   *
+   * @param enableEnginePlugin whether the script preprocessor engine plugin should be active
+   * @param rewriteCamundaReferencesInPackageRoot whether to rewrite root package names
+   *     ({@code org.camunda} -> {@code org.finos.fluxnova})
+   * @param rewriteCamundaReferencesInPackagePath whether to rewrite secondary package path segments
+   *     ({@code .camunda.} -> {@code .fluxnova.})
+   * @param rewriteCamundaReferencesInClassName whether to rewrite class name substrings
+   *     ({@code Camunda} -> {@code Fluxnova})
+   * @param defaultCamundaToFluxnovaPreprocessorEnabled whether to enable the default
+   *     Camunda-to-Fluxnova rewrite preprocessor
+   */
+  public ScriptingConfigurationProperties(
+      boolean enableEnginePlugin,
+      boolean rewriteCamundaReferencesInPackageRoot,
+      boolean rewriteCamundaReferencesInPackagePath,
+      boolean rewriteCamundaReferencesInClassName,
+      boolean defaultCamundaToFluxnovaPreprocessorEnabled) {
+    this.enableEnginePlugin = enableEnginePlugin;
+    this.rewriteCamundaReferencesInPackageRoot = rewriteCamundaReferencesInPackageRoot;
+    this.rewriteCamundaReferencesInPackagePath = rewriteCamundaReferencesInPackagePath;
+    this.rewriteCamundaReferencesInClassName = rewriteCamundaReferencesInClassName;
+    this.defaultCamundaToFluxnovaPreprocessorEnabled =
+        defaultCamundaToFluxnovaPreprocessorEnabled;
+  }
+
+  /** Returns {@code true} if the script preprocessor engine plugin should be active. */
+  public boolean isEnableEnginePlugin() {
+    return enableEnginePlugin;
+  }
+
+  /**
+   * Returns {@code true} if root package names ({@code org.camunda}) should be rewritten to
+   * ({@code org.finos.fluxnova}).
+   */
+  public boolean isRewriteCamundaReferencesInPackageRoot() {
+    return rewriteCamundaReferencesInPackageRoot;
+  }
+
+  /**
+   * Returns {@code true} if secondary package path segments ({@code .camunda.}) should be
+   * rewritten to ({@code .fluxnova.}).
+   */
+  public boolean isRewriteCamundaReferencesInPackagePath() {
+    return rewriteCamundaReferencesInPackagePath;
+  }
+
+  /**
+   * Returns {@code true} if class name substrings ({@code Camunda}) should be rewritten to
+   * ({@code Fluxnova}).
+   */
+  public boolean isRewriteCamundaReferencesInClassName() {
+    return rewriteCamundaReferencesInClassName;
+  }
+
+  /**
+   * Returns {@code true} if the default Camunda-to-Fluxnova rewrite preprocessor is enabled.
+   */
+  public boolean isDefaultCamundaToFluxnovaPreprocessorEnabled() {
+    return defaultCamundaToFluxnovaPreprocessorEnabled;
+  }
+  
+  /**
+   * Loads properties from {@code script-preprocessor.properties} on the classpath.
+   *
+   * <p>If the file is not found or cannot be read, an empty {@link Properties} instance is
+   * returned and a warning is logged; callers fall back to built-in defaults via
+   * {@link #resolveBoolean}.
+   *
+   * @return a {@link Properties} instance populated from the file, or empty on failure
+   */
+  private static Properties loadProperties() {
+    Properties props = new Properties();
+    try (InputStream in =
+        ScriptingConfigurationProperties.class
+            .getClassLoader()
+            .getResourceAsStream(PROPERTIES_FILE)) {
+      if (in == null) {
+        log.warn(
+            "Properties file '{}' not found on classpath; using built-in defaults.",
+            PROPERTIES_FILE);
+      } else {
+        props.load(in);
+        log.debug("Loaded properties from '{}'.", PROPERTIES_FILE);
+      }
+    } catch (IOException e) {
+      log.warn(
+          "Failed to load '{}'; using built-in defaults. Cause: {}",
+          PROPERTIES_FILE,
+          e.getMessage());
+    }
+    return props;
+  }
+
+  /**
+   * Resolves a boolean property. System properties take precedence over classpath file values,
+   * which in turn take precedence over the supplied {@code defaultValue}.
+   *
+   * <p>When a value is present but not a valid boolean ({@code true}/{@code false}), a warning is
+   * logged and the value is interpreted as {@code false}.
+   *
+   * @param props        base properties loaded from the classpath file
+   * @param preferredKey the preferred property key to look up first
+   * @param fallbackKey  the legacy fallback property key to look up if the preferred key is absent
+   * @param defaultValue fallback value when the key is absent from both system and file properties
+   * @return the resolved boolean value
+   */
+  private static boolean resolveBoolean(
+      Properties props, String preferredKey, String fallbackKey, boolean defaultValue) {
+    String systemValue = System.getProperty(preferredKey);
+    if (systemValue != null) {
+      return parseBooleanWithWarning(systemValue, preferredKey, "system property");
+    }
+    systemValue = System.getProperty(fallbackKey);
+    if (systemValue != null) {
+      return parseBooleanWithWarning(systemValue, fallbackKey, "system property");
+    }
+    String fileValue = props.getProperty(preferredKey);
+    if (fileValue != null) {
+      return parseBooleanWithWarning(fileValue, preferredKey, "classpath property file");
+    }
+    fileValue = props.getProperty(fallbackKey);
+    if (fileValue != null) {
+      return parseBooleanWithWarning(fileValue, fallbackKey, "classpath property file");
+    }
+    return defaultValue;
+  }
+
+  /**
+   * Parses a boolean value and warns when the input is non-boolean.
+   *
+   * <p>Valid values are {@code true} and {@code false} (case-insensitive). Invalid values are
+   * parsed as {@code false} to preserve {@link Boolean#parseBoolean(String)} behavior.
+   */
+  private static boolean parseBooleanWithWarning(String rawValue, String key, String source) {
+    String value = rawValue.trim();
+    if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+      log.warn(
+          "Invalid boolean value '{}' for key '{}' from {}; expected true/false. Interpreting as false.",
+          rawValue,
+          key,
+          source);
+    }
+    return Boolean.parseBoolean(value);
+  }
+}
+

--- a/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorAutoConfiguration.java
+++ b/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorAutoConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.spring;
+
+import java.util.List;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.plugin.ScriptPreprocessorPlugin;
+import org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor;
+import org.finos.fluxnova.plugin.preprocessor.core.ScriptingConfigurationProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Spring Boot auto-configuration for the Fluxnova script preprocessor plugin.
+ *
+ * <p>Registered via
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}
+ * and activated only when the Spring Boot auto-configuration infrastructure is present on the
+ * classpath ({@code @ConditionalOnClass}).
+ *
+ * <p>This configuration class:
+ * <ul>
+ *   <li>Binds {@link ScriptPreprocessorProperties} from the
+ *       {@code fluxnova.bpm.plugin.script-preprocessing.*} namespace.</li>
+ *   <li>Provides a {@link org.finos.fluxnova.plugin.ScriptPreprocessorPlugin} bean when
+ *       {@code enableEnginePlugin=true} and no user-defined bean of the same type exists.</li>
+ *   <li>Provides a {@link org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor}
+ *       bean when both {@code enableEnginePlugin=true} and
+ *       {@code defaultCamundaToFluxnovaPreprocessorEnabled=true}, and no user-defined bean of the
+ *       same type exists.</li>
+ * </ul>
+ *
+ * <p>Default property values are loaded from {@code script-preprocessor.properties} on the
+ * classpath and can be overridden via the Spring {@code Environment} (e.g.,
+ * {@code application.properties}, system properties, or environment variables).
+ *
+ * <p>Both beans support user backoff via {@code @ConditionalOnMissingBean}: declare your own
+ * {@link org.finos.fluxnova.plugin.ScriptPreprocessorPlugin} or
+ * {@link org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor} bean
+ * to suppress the auto-configured defaults.
+ *
+ * @see ScriptPreprocessorProperties
+ * @see org.finos.fluxnova.plugin.ScriptPreprocessorPlugin
+ * @see org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor
+ */
+@Configuration
+@ConditionalOnClass(name = "org.springframework.boot.autoconfigure.AutoConfiguration")
+@EnableConfigurationProperties({ScriptPreprocessorProperties.class})
+@PropertySource(value = "classpath:script-preprocessor.properties", ignoreResourceNotFound = true)
+public class ScriptPreprocessorAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(ScriptPreprocessorPlugin.class)
+  @ConditionalOnProperty(
+      prefix = "fluxnova.bpm.plugin.script-preprocessing",
+      name = "enableEnginePlugin",
+      havingValue = "true")
+  public ScriptPreprocessorPlugin scriptPreprocessorPlugin(
+      List<ScriptPreprocessor> userPreprocessors) {
+    ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+    // Prevent duplicate registration of the default preprocessor: it is managed as a separate bean.
+    plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+    plugin.setScriptPreprocessors(userPreprocessors);
+    return plugin;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(
+      CamundaToFluxnovaRewritePreprocessor.class)
+  @ConditionalOnProperty(
+      prefix = "fluxnova.bpm.plugin.script-preprocessing",
+      name = {"enableEnginePlugin","defaultCamundaToFluxnovaPreprocessorEnabled"},
+      havingValue = "true")
+  public CamundaToFluxnovaRewritePreprocessor
+      camundaToFluxnovaRewritePreprocessor(ScriptPreprocessorProperties props) {
+    return new CamundaToFluxnovaRewritePreprocessor(
+        new ScriptingConfigurationProperties(
+            props.isEnableEnginePlugin(),
+            props.isRewriteCamundaReferencesInRootPackage(),
+            props.isRewriteCamundaReferencesInPackagePath(),
+            props.isRewriteCamundaReferencesInClassName(),
+            props.isDefaultCamundaToFluxnovaPreprocessorEnabled()));
+  }
+}

--- a/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorProperties.java
+++ b/fluxnova-backward-compatibility-plugin/src/main/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorProperties.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Spring Boot configuration properties for the script preprocessor plugin.
+ *
+ * <p>Bound from the prefix
+ * {@code fluxnova.bpm.plugin.script-preprocessing}.
+ *
+ * <p>These properties are used only when the host application runs with Spring.
+ * Default values may be supplied from {@code script-preprocessor.properties} on the classpath.
+ */
+@ConfigurationProperties(prefix = "fluxnova.bpm.plugin.script-preprocessing")
+public class ScriptPreprocessorProperties {
+
+  private boolean enableEnginePlugin;
+
+  /** Enables the default Camunda-to-Fluxnova rewrite preprocessor in Spring environments. */
+  private boolean defaultCamundaToFluxnovaPreprocessorEnabled;
+
+  /** Rewrites the root package {@code org.camunda} to {@code org.finos.fluxnova}. */
+  private boolean rewriteCamundaReferencesInRootPackage;
+
+  /** Rewrites secondary package path segments from {@code .camunda} to {@code .fluxnova}. */
+  private boolean rewriteCamundaReferencesInPackagePath;
+
+  /** Rewrites class name substrings from {@code Camunda} to {@code Fluxnova}. */
+  private boolean rewriteCamundaReferencesInClassName;
+
+  public boolean isEnableEnginePlugin() {
+    return enableEnginePlugin;
+  }
+
+  public void setEnableEnginePlugin(boolean enableEnginePlugin) {
+    this.enableEnginePlugin = enableEnginePlugin;
+  }
+
+  public boolean isDefaultCamundaToFluxnovaPreprocessorEnabled() {
+    return defaultCamundaToFluxnovaPreprocessorEnabled;
+  }
+
+  public void setDefaultCamundaToFluxnovaPreprocessorEnabled(boolean defaultCamundaToFluxnovaPreprocessorEnabled) {
+    this.defaultCamundaToFluxnovaPreprocessorEnabled = defaultCamundaToFluxnovaPreprocessorEnabled;
+  }
+
+  public boolean isRewriteCamundaReferencesInRootPackage() {
+    return rewriteCamundaReferencesInRootPackage;
+  }
+
+  public void setRewriteCamundaReferencesInRootPackage(boolean rewriteCamundaReferencesInRootPackage) {
+    this.rewriteCamundaReferencesInRootPackage = rewriteCamundaReferencesInRootPackage;
+  }
+
+  public boolean isRewriteCamundaReferencesInPackagePath() {
+    return rewriteCamundaReferencesInPackagePath;
+  }
+
+  public void setRewriteCamundaReferencesInPackagePath(boolean rewriteCamundaReferencesInPackagePath) {
+    this.rewriteCamundaReferencesInPackagePath = rewriteCamundaReferencesInPackagePath;
+  }
+
+  public boolean isRewriteCamundaReferencesInClassName() {
+    return rewriteCamundaReferencesInClassName;
+  }
+
+  public void setRewriteCamundaReferencesInClassName(boolean rewriteCamundaReferencesInClassName) {
+    this.rewriteCamundaReferencesInClassName = rewriteCamundaReferencesInClassName;
+  }
+}

--- a/fluxnova-backward-compatibility-plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/fluxnova-backward-compatibility-plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.finos.fluxnova.plugin.preprocessor.spring.ScriptPreprocessorAutoConfiguration

--- a/fluxnova-backward-compatibility-plugin/src/main/resources/script-preprocessor.properties
+++ b/fluxnova-backward-compatibility-plugin/src/main/resources/script-preprocessor.properties
@@ -1,0 +1,22 @@
+# ============================================================
+# Script Preprocessor Plugin Configuration
+# ============================================================
+# Default values for script rewrite behavior.
+# These values apply unless overridden by Spring environment properties or JVM system properties.
+
+fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin=true
+
+# Enables the default CamundaToFluxnovaRewritePreprocessor bean in Spring environments.
+fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled=true
+
+# Controls root package replacement (org.camunda -> org.finos.fluxnova).
+# Set to 'true' ONLY after Fluxnova migration is complete.
+fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInRootPackage=true
+
+# Controls secondary package segment replacement (.camunda -> .fluxnova)
+# e.g. org.finos.fluxnova.camunda.foo -> org.finos.fluxnova.fluxnova.foo
+fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInPackagePath=false
+
+# Controls class name substring replacement (Camunda -> Fluxnova)
+# e.g. org.finos.fluxnova.CamundaTask -> org.finos.fluxnova.FluxnovaTask
+fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName=false

--- a/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/ScriptPreprocessorPluginTest.java
+++ b/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/ScriptPreprocessorPluginTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ScriptPreprocessorPlugin} in plain Java (non-Spring) startup mode.
+ *
+ * <p>All tests invoke {@link ScriptPreprocessorPlugin#preInit} directly with a mocked
+ * {@link ProcessEngineConfigurationImpl}, using JVM system properties to control
+ * {@link org.finos.fluxnova.plugin.preprocessor.core.ScriptingConfigurationProperties} resolution.
+ *
+ * <p>Coverage is organized into four nested groups:
+ * <ul>
+ *   <li><b>Master gate</b>: Verifies that {@code enableEnginePlugin=false} short-circuits
+ *       {@code preInit} before any engine configuration is touched.</li>
+ *   <li><b>Default preprocessor registration</b>: Verifies that
+ *       {@link CamundaToFluxnovaRewritePreprocessor} is registered when the default flag is enabled,
+ *       and skipped when disabled via the setter override.</li>
+ *   <li><b>Chaining and ordering</b>: Verifies that new preprocessors are appended to any existing
+ *       preprocessors on the engine config, and that the internal list is protected against external mutation.</li>
+ *   <li><b>Null and empty handling</b>: Verifies no-registration behavior when neither the default
+ *       preprocessor nor any custom preprocessors are active.</li>
+ * </ul>
+ *
+ * @see ScriptPreprocessorPlugin
+ */
+@DisplayName("ScriptPreprocessorPlugin - Java startup")
+class ScriptPreprocessorPluginTest {
+
+  private static final String PREFIX = "fluxnova.bpm.plugin.script-preprocessing.";
+
+  /**
+   * Clears system properties after each test to avoid cross-test pollution.
+   */
+  @AfterEach
+  void clearSystemProperties() {
+    System.clearProperty(PREFIX + "enableEnginePlugin");
+    System.clearProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled");
+  }
+
+  @Nested
+  @DisplayName("Master gate behavior")
+  class MasterGateBehavior {
+
+    @Test
+    @DisplayName("preInit returns immediately when enableEnginePlugin=false")
+    void preInit_returnsImmediately_whenEnginePluginDisabled() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "false");
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+
+      plugin.preInit(config);
+
+      verify(config, never()).setEnableScriptPreprocessing(true);
+      verify(config, never()).getScriptPreprocessors();
+      verify(config, never()).setScriptPreprocessors(org.mockito.ArgumentMatchers.anyList());
+    }
+  }
+
+  @Nested
+  @DisplayName("Default preprocessor registration")
+  class DefaultPreprocessorRegistration {
+
+    @Test
+    @DisplayName("Registers default CamundaToFluxnovaRewritePreprocessor when enabled")
+    void registersDefaultPreprocessor_whenEnabled() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+      System.setProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled", "true");
+
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(null);
+
+      plugin.preInit(config);
+
+      verify(config).setEnableScriptPreprocessing(true);
+      ArgumentCaptor<List<ScriptPreprocessor>> captor = ArgumentCaptor.forClass(List.class);
+      verify(config).setScriptPreprocessors(captor.capture());
+      List<ScriptPreprocessor> registered = captor.getValue();
+
+      assertEquals(1, registered.size());
+      assertInstanceOf(CamundaToFluxnovaRewritePreprocessor.class, registered.getFirst());
+    }
+
+    @Test
+    @DisplayName("Skips default preprocessor when explicitly disabled by setter")
+    void skipsDefaultPreprocessor_whenDisabledBySetter() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+      System.setProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled", "true");
+
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(null);
+
+      plugin.preInit(config);
+
+      verify(config, never()).setEnableScriptPreprocessing(true);
+      verify(config, never()).setScriptPreprocessors(org.mockito.ArgumentMatchers.anyList());
+    }
+  }
+
+  @Nested
+  @DisplayName("Chaining and ordering")
+  class ChainingAndOrdering {
+
+    @Test
+    @DisplayName("Appends to existing preprocessors instead of replacing")
+    void appendsToExistingPreprocessors_inOrder() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+      System.setProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled", "true");
+
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      ScriptPreprocessor custom = mock(ScriptPreprocessor.class);
+      plugin.setScriptPreprocessors(List.of(custom));
+
+      ScriptPreprocessor existing = mock(ScriptPreprocessor.class);
+      List<ScriptPreprocessor> existingList = new ArrayList<>();
+      existingList.add(existing);
+
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(existingList);
+
+      plugin.preInit(config);
+
+      verify(config).setEnableScriptPreprocessing(true);
+      verify(config, never()).setScriptPreprocessors(org.mockito.ArgumentMatchers.anyList());
+
+      assertEquals(3, existingList.size());
+      assertSame(existing, existingList.get(0));
+      assertInstanceOf(CamundaToFluxnovaRewritePreprocessor.class, existingList.get(1));
+      assertSame(custom, existingList.get(2));
+    }
+
+    @Test
+    @DisplayName("Setter protects against external list mutation")
+    void setter_defensiveCopy_protectsFromExternalMutation() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+
+      ScriptPreprocessor custom = mock(ScriptPreprocessor.class);
+      List<ScriptPreprocessor> input = new ArrayList<>();
+      input.add(custom);
+      plugin.setScriptPreprocessors(input);
+
+      // Mutate caller-owned list after passing it to plugin
+      input.clear();
+
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(null);
+
+      plugin.preInit(config);
+
+      ArgumentCaptor<List<ScriptPreprocessor>> captor = ArgumentCaptor.forClass(List.class);
+      verify(config).setScriptPreprocessors(captor.capture());
+      List<ScriptPreprocessor> registered = captor.getValue();
+
+      assertEquals(1, registered.size());
+      assertSame(custom, registered.getFirst());
+    }
+  }
+
+  @Nested
+  @DisplayName("Null and empty handling")
+  class NullAndEmptyHandling {
+
+    @Test
+    @DisplayName("Null custom list with default disabled results in no preprocessor registration")
+    void noRegistration_whenNoDefaultAndNoCustoms() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+      plugin.setScriptPreprocessors(null);
+
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(null);
+
+      plugin.preInit(config);
+
+      verify(config, never()).setEnableScriptPreprocessing(true);
+      verify(config, never()).setScriptPreprocessors(org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    @DisplayName("Empty custom list with default disabled results in no preprocessor registration")
+    void noRegistration_whenNoDefaultAndEmptyCustomList() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+      plugin.setScriptPreprocessors(List.of());
+
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(null);
+
+      plugin.preInit(config);
+
+      verify(config, never()).setEnableScriptPreprocessing(true);
+      verify(config, never()).setScriptPreprocessors(org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    @DisplayName("Setting custom preprocessors only registers exactly those when default disabled")
+    void registersOnlyCustomPreprocessors_whenDefaultDisabled() {
+      System.setProperty(PREFIX + "enableEnginePlugin", "true");
+
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+
+      ScriptPreprocessor customA = mock(ScriptPreprocessor.class);
+      ScriptPreprocessor customB = mock(ScriptPreprocessor.class);
+      plugin.setScriptPreprocessors(List.of(customA, customB));
+
+      ProcessEngineConfigurationImpl config = mock(ProcessEngineConfigurationImpl.class);
+      when(config.getScriptPreprocessors()).thenReturn(null);
+
+      plugin.preInit(config);
+
+      ArgumentCaptor<List<ScriptPreprocessor>> captor = ArgumentCaptor.forClass(List.class);
+      verify(config).setScriptPreprocessors(captor.capture());
+      List<ScriptPreprocessor> registered = captor.getValue();
+
+      assertEquals(2, registered.size());
+      assertSame(customA, registered.get(0));
+      assertSame(customB, registered.get(1));
+      assertFalse(registered.get(0) instanceof CamundaToFluxnovaRewritePreprocessor);
+      assertFalse(registered.get(1) instanceof CamundaToFluxnovaRewritePreprocessor);
+      assertTrue(registered.contains(customA));
+      assertTrue(registered.contains(customB));
+    }
+  }
+}
+

--- a/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/core/CamundaToFluxnovaRewritePreprocessorTest.java
+++ b/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/core/CamundaToFluxnovaRewritePreprocessorTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.core;
+
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CamundaToFluxnovaRewritePreprocessor}.
+ *
+ * <p>Each test constructs the preprocessor with an explicit
+ * {@link ScriptingConfigurationProperties} via the programmatic constructor, allowing precise
+ * control over which rewrite flags are active. This isolates the rewrite logic from the classpath
+ * property-loading path tested in {@link ScriptPreprocessorJavaConfigIT}.
+ *
+ * <p>Coverage includes:
+ * <ul>
+ *   <li>Null and empty input handling</li>
+ *   <li>Each rewrite mode individually</li>
+ *   <li>All rewrite modes combined</li>
+ *   <li>Boundary conditions on class-name casing</li>
+ *   <li>Explicit fail-open (internal error fallback)</li>
+ * </ul>
+ *
+ * @see CamundaToFluxnovaRewritePreprocessor
+ * @see ScriptingConfigurationProperties
+ */
+@DisplayName("CamundaToFluxnovaRewritePreprocessor")
+class CamundaToFluxnovaRewritePreprocessorTest {
+
+  /**
+   * Utility to create a mock ScriptPreprocessorRequest with the given script.
+   */
+  private static ScriptPreprocessorRequest requestWithScript(String script) {
+    ScriptPreprocessorRequest request = mock(ScriptPreprocessorRequest.class);
+    when(request.getScript()).thenReturn(script);
+    return request;
+  }
+
+  @Test
+  @DisplayName("Returns null when request is null")
+  void returnsNullWhenRequestIsNull() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties(true, true, true, true, true));
+
+    assertNull(preprocessor.process(null));
+  }
+
+  @Test
+  @DisplayName("Returns null when script is null")
+  void returnsOriginalWhenScriptIsNull() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties(true, true, true, true, true));
+
+    assertNull(preprocessor.process(requestWithScript(null)));
+  }
+
+  @Test
+  @DisplayName("Returns original script when script is empty")
+  void returnsOriginalWhenScriptIsEmpty() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties(true, true, true, true, true));
+
+    assertEquals("", preprocessor.process(requestWithScript("")));
+  }
+
+  @Test
+  @DisplayName("Returns original script when no org.camunda references are present")
+  void returnsOriginalWhenNoCamundaReferencesPresent() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties(true, true, true, true, true));
+    String input = "var value = com.acme.foo.Bar;";
+
+    assertEquals(input, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Rewrites root package only when only root rewrite is enabled")
+  void rewritesRootPackageOnly() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(
+            new ScriptingConfigurationProperties(true, true, false, false, true));
+    String input = "org.camunda.bpm.camunda.engine.CamundaProcessEngine";
+    String expected = "org.finos.fluxnova.bpm.camunda.engine.CamundaProcessEngine";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Rewrites package path segments when package-path rewrite is enabled")
+  void rewritesPackagePathSegments() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(
+            new ScriptingConfigurationProperties(true, true, true, false, true));
+    String input = "org.camunda.bpm.camunda.runtime.CamundaTask";
+    String expected = "org.finos.fluxnova.bpm.fluxnova.runtime.CamundaTask";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Rewrites class name substrings when class-name rewrite is enabled")
+  void rewritesClassNameSubstrings() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(
+            new ScriptingConfigurationProperties(true, true, false, true, true));
+    String input = "org.camunda.bpm.runtime.MyCamundaTask";
+    String expected = "org.finos.fluxnova.bpm.runtime.MyFluxnovaTask";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Applies all rewrites when all rewrite flags are enabled")
+  void appliesAllRewritesWhenEnabled() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(
+            new ScriptingConfigurationProperties(true, true, true, true, true));
+    String input = "org.camunda.bpm.camunda.runtime.MyCamundaTask";
+    String expected = "org.finos.fluxnova.bpm.fluxnova.runtime.MyFluxnovaTask";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Rewrites multiple references on one line with mixed rewrite modes")
+  void rewritesMultipleReferencesOnOneLineWithMixedModes() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(
+            new ScriptingConfigurationProperties(true, true, false, true, true));
+    String input = "org.camunda.a.CamundaX + org.camunda.b.camunda.CamundaY";
+    // root-package and class-name rewrites are on; package-path rewrite remains off.
+    String expected = "org.finos.fluxnova.a.FluxnovaX + org.finos.fluxnova.b.camunda.FluxnovaY";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Preserves class name when it does not start with uppercase")
+  void doesNotRewriteClassNameThatStartsLowercase() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(
+            new ScriptingConfigurationProperties(true, true, false, true, true));
+    String input = "org.camunda.bpm.runtime.camundaTask";
+    String expected = "org.finos.fluxnova.bpm.runtime.camundaTask";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("With null config, implementation falls back to default config")
+  void returnsOriginalScriptOnInternalError() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        new CamundaToFluxnovaRewritePreprocessor(null);
+    String input = "org.camunda.bpm.runtime.CamundaTask";
+    String expected = "org.finos.fluxnova.bpm.runtime.CamundaTask";
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Returns original script if replacePackage throws an exception (explicit fail-open)")
+  void returnsOriginalScriptIfReplacePackageThrows() {
+    CamundaToFluxnovaRewritePreprocessor preprocessor = new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties(true, true, true, true, true)) {
+      @Override
+      protected String replacePackage(String script) {
+        throw new RuntimeException("Simulated failure");
+      }
+    };
+    String input = "org.camunda.bpm.runtime.CamundaTask";
+
+    assertEquals(input, preprocessor.process(requestWithScript(input)));
+  }
+}

--- a/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/core/ScriptPreprocessorJavaConfigIT.java
+++ b/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/core/ScriptPreprocessorJavaConfigIT.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.core;
+
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for the script preprocessor in plain Java (non-Spring) environments.
+ *
+ * <p>Each test exercises the Java-only configuration chain without starting a Spring context:
+ * <ol>
+ *   <li>{@link ScriptingConfigurationProperties} is instantiated via the no-arg constructor,
+ *       loading values from {@code script-preprocessor.properties} on the classpath.</li>
+ *   <li>A {@link CamundaToFluxnovaRewritePreprocessor} is created with those loaded properties.</li>
+ *   <li>The {@code process()} method is invoked and its output is asserted.</li>
+ * </ol>
+ *
+ * <p>This complements the unit tests in {@link CamundaToFluxnovaRewritePreprocessorTest}, which
+ * construct {@link ScriptingConfigurationProperties} via the explicit constructor. Here, properties
+ * are resolved from the real classpath file and (optionally) overridden via JVM system properties,
+ * exercising the same configuration path used in non-Spring deployments.
+ *
+ * <p>Coverage includes:
+ * <ul>
+ *   <li>Classpath default property values: root package rewrite only.</li>
+ *   <li>Variable binding safety: BPM-injected variables (e.g., {@code execution}, {@code task}) and plain
+ *       {@code camunda}/{@code Camunda} identifiers are not rewritten.</li>
+ *   <li>JVM system property overrides enabling each optional rewrite flag individually and in combination.</li>
+ *   <li>Disabling the root package rewrite so the script is returned unchanged.</li>
+ * </ul>
+ *
+ * @see ScriptingConfigurationProperties
+ * @see CamundaToFluxnovaRewritePreprocessor
+ * @see CamundaToFluxnovaRewritePreprocessorTest
+ */
+@DisplayName("ScriptPreprocessorPlugin Java-path integration")
+class ScriptPreprocessorJavaConfigIT {
+
+  private static final String PREFIX = "fluxnova.bpm.plugin.script-preprocessing.";
+
+  /**
+   * Utility to create a mock ScriptPreprocessorRequest with the given script.
+   */
+  private static ScriptPreprocessorRequest requestWithScript(String script) {
+    ScriptPreprocessorRequest request = mock(ScriptPreprocessorRequest.class);
+    when(request.getScript()).thenReturn(script);
+    return request;
+  }
+
+  @AfterEach
+  void clearSystemProperties() {
+    System.clearProperty(PREFIX + "enableEnginePlugin");
+    System.clearProperty(PREFIX + "rewriteCamundaReferencesInRootPackage");
+    System.clearProperty(PREFIX + "rewriteCamundaReferencesInPackagePath");
+    System.clearProperty(PREFIX + "rewriteCamundaReferencesInClassName");
+    System.clearProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled");
+  }
+
+  // -------------------------------------------------------------------------
+  // Classpath defaults (no system property overrides)
+  // -------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Classpath defaults")
+  class ClasspathDefaults {
+
+    @Test
+    @DisplayName("Rewrites root package only; package path and class name remain unchanged")
+    void rewritesRootPackageOnly() {
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      // Only the root package (org.camunda) is rewritten; secondary package and class name are not.
+      assertEquals(
+          "org.finos.fluxnova.bpm.camunda.engine.CamundaProcessEngine",
+          preprocessor.process(
+              requestWithScript("org.camunda.bpm.camunda.engine.CamundaProcessEngine")));
+    }
+
+    @Test
+    @DisplayName("Script without org.camunda references is returned unchanged")
+    void scriptWithoutCamundaReferencesIsReturnedUnchanged() {
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      String input = "com.acme.service.MyTask";
+      assertEquals(input, preprocessor.process(requestWithScript(input)));
+    }
+
+    @Test
+    @DisplayName("Rewrites Camunda type references but preserves BPM-injected variable names")
+    void rewritesCamundaTypesButPreservesBpmInjectedVariableNames() {
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      // Simulates a Groovy BPM script:
+      // - 'execution' and 'task' are BPM-injected variable bindings: must NOT be rewritten
+      // - Camunda type references in import, cast, and declaration positions: must be rewritten
+      String input = String.join("\n",
+          "import org.camunda.bpm.engine.delegate.DelegateExecution",
+          "org.camunda.bpm.engine.delegate.DelegateExecution delegateExec = (org.camunda.bpm.engine.delegate.DelegateExecution) execution",
+          "org.camunda.bpm.engine.RuntimeService runtimeService = execution.getProcessEngineServices().getRuntimeService()",
+          "runtimeService.startProcessInstanceByKey(execution.getVariable('processKey') as String)",
+          "def taskName = task.getName()"
+      );
+
+      String expected = String.join("\n",
+          "import org.finos.fluxnova.bpm.engine.delegate.DelegateExecution",
+          "org.finos.fluxnova.bpm.engine.delegate.DelegateExecution delegateExec = (org.finos.fluxnova.bpm.engine.delegate.DelegateExecution) execution",
+          "org.finos.fluxnova.bpm.engine.RuntimeService runtimeService = execution.getProcessEngineServices().getRuntimeService()",
+          "runtimeService.startProcessInstanceByKey(execution.getVariable('processKey') as String)",
+          "def taskName = task.getName()"
+      );
+
+      assertEquals(expected, preprocessor.process(requestWithScript(input)));
+    }
+
+    @Test
+    @DisplayName("Variable names 'camunda' and 'Camunda' are preserved as plain identifiers")
+    void variableNamedCamundaOrCamundaIsNotRewritten() {
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      // 'camunda' and 'Camunda' appear as variable names, parameter names, or string literals —
+      // none of these start with 'org.' so the root package pattern does not match them.
+      String input = String.join("\n",
+          "def camunda = execution.getVariable('camundaService')",
+          "org.camunda.bpm.engine.ProcessEngine camundaEngine = camunda.getProcessEngine()",
+          "Camunda.configure(camundaEngine)",
+          "execution.setVariable('camundaResult', camunda.getStatus())"
+      );
+
+      // Only the fully-qualified org.camunda type reference on line 2 is rewritten.
+      // Variable names (camunda, camundaEngine), the 'Camunda' class call, and string literals are untouched.
+      String expected = String.join("\n",
+          "def camunda = execution.getVariable('camundaService')",
+          "org.finos.fluxnova.bpm.engine.ProcessEngine camundaEngine = camunda.getProcessEngine()",
+          "Camunda.configure(camundaEngine)",
+          "execution.setVariable('camundaResult', camunda.getStatus())"
+      );
+
+      assertEquals(expected, preprocessor.process(requestWithScript(input)));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // JVM system property overrides
+  // -------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("JVM system property overrides")
+  class SystemPropertyOverrides {
+
+    @Test
+    @DisplayName("Enabling rewriteCamundaReferencesInPackagePath rewrites secondary package segments")
+    void systemPropertyEnablesPackagePathRewrite() {
+      System.setProperty(PREFIX + "rewriteCamundaReferencesInPackagePath", "true");
+
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      // Both root package and .camunda. segments are rewritten.
+      assertEquals(
+          "org.finos.fluxnova.bpm.fluxnova.engine.CamundaProcessEngine",
+          preprocessor.process(
+              requestWithScript("org.camunda.bpm.camunda.engine.CamundaProcessEngine")));
+    }
+
+    @Test
+    @DisplayName("Enabling rewriteCamundaReferencesInClassName rewrites class name substrings")
+    void systemPropertyEnablesClassNameRewrite() {
+      System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "true");
+
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      // Root package is rewritten; class name 'Camunda' is also rewritten.
+      assertEquals(
+          "org.finos.fluxnova.bpm.camunda.engine.FluxnovaProcessEngine",
+          preprocessor.process(
+              requestWithScript("org.camunda.bpm.camunda.engine.CamundaProcessEngine")));
+    }
+
+    @Test
+    @DisplayName("All rewrite flags enabled produces fully migrated output")
+    void allRewriteFlagsEnabledProducesFullyMigratedOutput() {
+      System.setProperty(PREFIX + "rewriteCamundaReferencesInPackagePath", "true");
+      System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "true");
+
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      assertEquals(
+          "org.finos.fluxnova.bpm.fluxnova.runtime.MyFluxnovaTask",
+          preprocessor.process(
+              requestWithScript("org.camunda.bpm.camunda.runtime.MyCamundaTask")));
+    }
+
+    @Test
+    @DisplayName("Disabling rewriteCamundaReferencesInRootPackage leaves root package unchanged")
+    void disablingRootPackageRewriteLeavesRootPackageUntouched() {
+      System.setProperty(PREFIX + "rewriteCamundaReferencesInRootPackage", "false");
+
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          new CamundaToFluxnovaRewritePreprocessor(new ScriptingConfigurationProperties());
+
+      // All rewrites disabled; script is returned unchanged.
+      String input = "org.camunda.bpm.engine.ProcessEngine";
+      assertEquals(input, preprocessor.process(requestWithScript(input)));
+    }
+  }
+}
+

--- a/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/core/ScriptingConfigurationPropertiesTest.java
+++ b/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/core/ScriptingConfigurationPropertiesTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.core;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ScriptingConfigurationProperties}.
+ *
+ * <p>Tests cover all property resolution paths in priority order:
+ * <ol>
+ *   <li>JVM system property override (highest priority)</li>
+ *   <li>Classpath {@code script-preprocessor.properties} file values</li>
+ *   <li>Built-in hard-coded defaults (lowest priority)</li>
+ * </ol>
+ * Also verifies the explicit/programmatic constructor used by Spring and direct instantiation.
+ */
+@DisplayName("ScriptingConfigurationProperties")
+class ScriptingConfigurationPropertiesTest {
+
+    private static final String PREFIX = "fluxnova.bpm.plugin.script-preprocessing.";
+
+    /**
+     * Clears any system properties set during a test to avoid cross-test pollution.
+     */
+    @AfterEach
+    void clearSystemProperties() {
+        System.clearProperty(PREFIX + "enableEnginePlugin");
+        System.clearProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled");
+        System.clearProperty(PREFIX + "rewriteCamundaReferencesInRootPackage");
+        System.clearProperty(PREFIX + "rewriteCamundaReferencesInPackagePath");
+        System.clearProperty(PREFIX + "rewriteCamundaReferencesInClassName");
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. Classpath file defaults (script-preprocessor.properties on classpath)
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Classpath file defaults")
+    class ClasspathFileDefaults {
+
+        @Test
+        @DisplayName("enableEnginePlugin defaults to true from properties file")
+        void enableEnginePlugin_defaultsToTrue() {
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isEnableEnginePlugin());
+        }
+
+        @Test
+        @DisplayName("defaultCamundaToFluxnovaPreprocessorEnabled defaults to true from properties file")
+        void defaultCamundaToFluxnovaPreprocessorEnabled_defaultsToTrue() {
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+        }
+
+        @Test
+        @DisplayName("rewriteCamundaReferencesInRootPackage defaults to true from properties file")
+        void rewriteRootPackage_defaultsToTrue() {
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isRewriteCamundaReferencesInPackageRoot());
+        }
+
+        @Test
+        @DisplayName("rewriteCamundaReferencesInPackagePath defaults to false from properties file")
+        void rewritePackagePath_defaultsToFalse() {
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertFalse(props.isRewriteCamundaReferencesInPackagePath());
+        }
+
+        @Test
+        @DisplayName("rewriteCamundaReferencesInClassName defaults to false from properties file")
+        void rewriteClassName_defaultsToFalse() {
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertFalse(props.isRewriteCamundaReferencesInClassName());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. JVM system property overrides (highest priority)
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("JVM system property overrides")
+    class SystemPropertyOverrides {
+
+        @Test
+        @DisplayName("System property overrides enableEnginePlugin to false")
+        void systemProperty_overridesEnableEnginePlugin_toFalse() {
+            System.setProperty(PREFIX + "enableEnginePlugin", "false");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertFalse(props.isEnableEnginePlugin());
+        }
+
+        @Test
+        @DisplayName("System property overrides enableEnginePlugin to true")
+        void systemProperty_overridesEnableEnginePlugin_toTrue() {
+            System.setProperty(PREFIX + "enableEnginePlugin", "true");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isEnableEnginePlugin());
+        }
+
+        @Test
+        @DisplayName("System property overrides defaultCamundaToFluxnovaPreprocessorEnabled to false")
+        void systemProperty_overridesDefaultPreprocessorEnabled_toFalse() {
+            System.setProperty(PREFIX + "defaultCamundaToFluxnovaPreprocessorEnabled", "false");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertFalse(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+        }
+
+        @Test
+        @DisplayName("System property overrides rewriteCamundaReferencesInRootPackage to false")
+        void systemProperty_overridesRewriteRootPackage_toFalse() {
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInRootPackage", "false");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertFalse(props.isRewriteCamundaReferencesInPackageRoot());
+        }
+
+        @Test
+        @DisplayName("System property overrides rewriteCamundaReferencesInPackagePath to true")
+        void systemProperty_overridesRewritePackagePath_toTrue() {
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInPackagePath", "true");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isRewriteCamundaReferencesInPackagePath());
+        }
+
+        @Test
+        @DisplayName("System property overrides rewriteCamundaReferencesInClassName to true")
+        void systemProperty_overridesRewriteClassName_toTrue() {
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "true");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isRewriteCamundaReferencesInClassName());
+        }
+
+        @Test
+        @DisplayName("System property value is trimmed before parsing")
+        void systemProperty_valueIsTrimmed() {
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "  true  ");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            assertTrue(props.isRewriteCamundaReferencesInClassName());
+        }
+
+        @Test
+        @DisplayName("Invalid system property value is treated as false")
+        void systemProperty_invalidValue_treatedAsFalse() {
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "yes");
+            ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+            // Boolean.parseBoolean("yes") == false
+            assertFalse(props.isRewriteCamundaReferencesInClassName());
+        }
+
+        @Test
+        @DisplayName("Invalid system property value logs warning and is treated as false")
+        void systemProperty_invalidValue_logsWarningAndTreatedAsFalse() {
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "yes");
+            Logger logger = (Logger) LoggerFactory.getLogger(ScriptingConfigurationProperties.class);
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.addAppender(appender);
+            try {
+                ScriptingConfigurationProperties props = new ScriptingConfigurationProperties();
+                assertFalse(props.isRewriteCamundaReferencesInClassName());
+
+                assertTrue(
+                    appender.list.stream().anyMatch(event ->
+                        event.getLevel() == Level.WARN
+                            && event.getFormattedMessage().contains("Invalid boolean value")
+                            && event.getFormattedMessage().contains("rewriteCamundaReferencesInClassName")
+                            && event.getFormattedMessage().contains("system property")));
+            } finally {
+                logger.detachAppender(appender);
+                appender.stop();
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. Explicit (programmatic) constructor
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Explicit constructor (programmatic / Spring delegation)")
+    class ExplicitConstructor {
+
+        @Test
+        @DisplayName("All flags set to true are preserved")
+        void allTrue() {
+            ScriptingConfigurationProperties props =
+                new ScriptingConfigurationProperties(true, true, true, true, true);
+            assertTrue(props.isEnableEnginePlugin());
+            assertTrue(props.isRewriteCamundaReferencesInPackageRoot());
+            assertTrue(props.isRewriteCamundaReferencesInPackagePath());
+            assertTrue(props.isRewriteCamundaReferencesInClassName());
+            assertTrue(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+        }
+
+        @Test
+        @DisplayName("All flags set to false are preserved")
+        void allFalse() {
+            ScriptingConfigurationProperties props =
+                new ScriptingConfigurationProperties(false, false, false, false, false);
+            assertFalse(props.isEnableEnginePlugin());
+            assertFalse(props.isRewriteCamundaReferencesInPackageRoot());
+            assertFalse(props.isRewriteCamundaReferencesInPackagePath());
+            assertFalse(props.isRewriteCamundaReferencesInClassName());
+            assertFalse(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+        }
+
+        @Test
+        @DisplayName("Mixed flags are stored independently")
+        void mixedFlags() {
+            ScriptingConfigurationProperties props =
+                new ScriptingConfigurationProperties(true, true, false, false, true);
+            assertTrue(props.isEnableEnginePlugin());
+            assertTrue(props.isRewriteCamundaReferencesInPackageRoot());
+            assertFalse(props.isRewriteCamundaReferencesInPackagePath());
+            assertFalse(props.isRewriteCamundaReferencesInClassName());
+            assertTrue(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+        }
+
+        @Test
+        @DisplayName("Explicit constructor is not affected by JVM system properties")
+        void explicitConstructor_ignoresSystemProperties() {
+            System.setProperty(PREFIX + "enableEnginePlugin", "false");
+            System.setProperty(PREFIX + "rewriteCamundaReferencesInClassName", "true");
+            // Explicit constructor bypasses property resolution entirely
+            ScriptingConfigurationProperties props =
+                new ScriptingConfigurationProperties(true, true, false, false, true);
+            assertTrue(props.isEnableEnginePlugin());
+            assertFalse(props.isRewriteCamundaReferencesInClassName());
+        }
+    }
+}
+

--- a/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorAutoConfigurationIT.java
+++ b/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorAutoConfigurationIT.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.spring;
+
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.finos.fluxnova.plugin.ScriptPreprocessorPlugin;
+import org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor;
+import org.finos.fluxnova.plugin.preprocessor.core.ScriptingConfigurationProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for {@link ScriptPreprocessorAutoConfiguration} using a real Spring Boot application context.
+ *
+ * <p>Each test starts a Spring Boot context to verify auto-configuration via
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports} discovery.
+ *
+ * <p>Coverage includes:
+ * <ul>
+ *   <li>Auto-configuration discovery and default bean registration</li>
+ *   <li>End-to-end preprocessor output with classpath defaults and JVM system property overrides</li>
+ *   <li>Negative gate: plugin and preprocessor beans absent when {@code enableEnginePlugin=false}</li>
+ *   <li>User-defined bean backoff for both {@link ScriptPreprocessorPlugin} and {@link CamundaToFluxnovaRewritePreprocessor}</li>
+ *   <li>BPM variable binding safety: plain {@code camunda}/{@code Camunda} identifiers and engine-injected variables are not rewritten</li>
+ * </ul>
+ *
+ * <p>For property binding assertions without a full Boot context, see {@code ScriptPreprocessorAutoConfigurationTest}.
+ *
+ * @see ScriptPreprocessorAutoConfiguration
+ * @see ScriptPreprocessorProperties
+ */
+@DisplayName("ScriptPreprocessorAutoConfiguration integration")
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
+class ScriptPreprocessorAutoConfigurationIT {
+
+  private static ConfigurableApplicationContext sharedDefaultContext;
+
+  /**
+   * Utility to create a mock ScriptPreprocessorRequest with the given script.
+   */
+  private static ScriptPreprocessorRequest requestWithScript(String script) {
+    ScriptPreprocessorRequest request = mock(ScriptPreprocessorRequest.class);
+    when(request.getScript()).thenReturn(script);
+    return request;
+  }
+
+  /**
+   * Starts a Spring Boot application context with the given sources and properties.
+   */
+  private static ConfigurableApplicationContext runContext(Class<?>[] sources, String... properties) {
+    return new SpringApplicationBuilder(sources)
+        .web(WebApplicationType.NONE)
+        .properties(properties)
+        .run();
+  }
+
+  @BeforeAll
+  static void startSharedDefaultContext() {
+    sharedDefaultContext = runContext(new Class<?>[] {IntegrationTestApplication.class});
+  }
+
+  @AfterAll
+  static void stopSharedDefaultContext() {
+    if (sharedDefaultContext != null) {
+      sharedDefaultContext.close();
+    }
+  }
+
+  private static ConfigurableApplicationContext defaultContext() {
+    return sharedDefaultContext;
+  }
+
+  @Test
+  @DisplayName("Auto-configuration imports register default beans and bind classpath defaults")
+  void autoConfigurationImportsRegisterDefaultBeansAndBindClasspathDefaults() {
+    ConfigurableApplicationContext context = defaultContext();
+    assertEquals(1, context.getBeansOfType(ScriptPreprocessorProperties.class).size());
+    assertEquals(1, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+    assertEquals(1, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+
+    ScriptPreprocessorProperties props = context.getBean(ScriptPreprocessorProperties.class);
+    assertTrue(props.isEnableEnginePlugin());
+    assertTrue(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+    assertTrue(props.isRewriteCamundaReferencesInRootPackage());
+    assertFalse(props.isRewriteCamundaReferencesInPackagePath());
+    assertFalse(props.isRewriteCamundaReferencesInClassName());
+  }
+
+  @Test
+  @DisplayName("Default preprocessor rewrites root package only with classpath defaults")
+  void defaultPreprocessorRewritesRootPackageOnlyWithClasspathDefaults() {
+    ConfigurableApplicationContext context = defaultContext();
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        context.getBean(CamundaToFluxnovaRewritePreprocessor.class);
+    // root package rewritten; secondary package path and class name left untouched (defaults)
+    assertEquals(
+        "org.finos.fluxnova.bpm.camunda.engine.CamundaProcessEngine",
+        preprocessor.process(requestWithScript("org.camunda.bpm.camunda.engine.CamundaProcessEngine")));
+  }
+
+  @Test
+  @DisplayName("Default preprocessor rewrites Camunda type references but preserves BPM-injected variable names")
+  void defaultPreprocessorRewritesCamundaTypesButPreservesBpmInjectedVariableNames() {
+    ConfigurableApplicationContext context = defaultContext();
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        context.getBean(CamundaToFluxnovaRewritePreprocessor.class);
+
+    // Simulates a realistic Groovy BPM script:
+    // - 'execution' and 'task' are BPM-injected variable bindings: must NOT be rewritten
+    // - Camunda type references in casts and declarations: must be rewritten
+    String input = String.join("\n",
+        "import org.camunda.bpm.engine.delegate.DelegateExecution",
+        "org.camunda.bpm.engine.delegate.DelegateExecution delegateExec = (org.camunda.bpm.engine.delegate.DelegateExecution) execution",
+        "org.camunda.bpm.engine.RuntimeService runtimeService = execution.getProcessEngineServices().getRuntimeService()",
+        "runtimeService.startProcessInstanceByKey(execution.getVariable('processKey') as String)",
+        "def taskName = task.getName()"
+    );
+
+    // Camunda type references are rewritten; BPM variable names (execution, task) are untouched
+    String expected = String.join("\n",
+        "import org.finos.fluxnova.bpm.engine.delegate.DelegateExecution",
+        "org.finos.fluxnova.bpm.engine.delegate.DelegateExecution delegateExec = (org.finos.fluxnova.bpm.engine.delegate.DelegateExecution) execution",
+        "org.finos.fluxnova.bpm.engine.RuntimeService runtimeService = execution.getProcessEngineServices().getRuntimeService()",
+        "runtimeService.startProcessInstanceByKey(execution.getVariable('processKey') as String)",
+        "def taskName = task.getName()"
+    );
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("Variable names 'camunda' and 'Camunda' are preserved when they are plain identifiers, not package references")
+  void variableNamedCamundaOrCamundaIsNotRewritten() {
+    ConfigurableApplicationContext context = defaultContext();
+    CamundaToFluxnovaRewritePreprocessor preprocessor =
+        context.getBean(CamundaToFluxnovaRewritePreprocessor.class);
+
+    // 'camunda' and 'Camunda' appear as variable names / call targets / string literals —
+    // none of these start with 'org.' so the root package pattern must not match them.
+    String input = String.join("\n",
+        "def camunda = execution.getVariable('camundaService')",
+        "org.camunda.bpm.engine.ProcessEngine camundaEngine = camunda.getProcessEngine()",
+        "Camunda.configure(camundaEngine)",
+        "execution.setVariable('camundaResult', camunda.getStatus())"
+    );
+
+    // Only the fully-qualified org.camunda type reference on line 2 is rewritten.
+    // Variable names (camunda, camundaEngine), the 'Camunda' call, and string literals are untouched.
+    String expected = String.join("\n",
+        "def camunda = execution.getVariable('camundaService')",
+        "org.finos.fluxnova.bpm.engine.ProcessEngine camundaEngine = camunda.getProcessEngine()",
+        "Camunda.configure(camundaEngine)",
+        "execution.setVariable('camundaResult', camunda.getStatus())"
+    );
+
+    assertEquals(expected, preprocessor.process(requestWithScript(input)));
+  }
+
+  @Test
+  @DisplayName("JVM system property overrides are wired into the default preprocessor bean")
+  void jvmSystemPropertyOverridesAreWiredIntoDefaultPreprocessorBean() {
+    String packagePathKey =
+        "fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInPackagePath";
+    String classNameKey =
+        "fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName";
+    // Intentionally uses JVM system properties to override values through Spring Environment.
+    System.setProperty(packagePathKey, "true");
+    System.setProperty(classNameKey, "true");
+    try (ConfigurableApplicationContext context =
+        runContext(new Class<?>[] {IntegrationTestApplication.class})) {
+      ScriptPreprocessorProperties props = context.getBean(ScriptPreprocessorProperties.class);
+      assertTrue(props.isRewriteCamundaReferencesInPackagePath());
+      assertTrue(props.isRewriteCamundaReferencesInClassName());
+
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          context.getBean(CamundaToFluxnovaRewritePreprocessor.class);
+
+      String input = "org.camunda.bpm.camunda.runtime.MyCamundaTask";
+      String expected = "org.finos.fluxnova.bpm.fluxnova.runtime.MyFluxnovaTask";
+
+      assertEquals(expected, preprocessor.process(requestWithScript(input)));
+    } finally {
+      System.clearProperty(packagePathKey);
+      System.clearProperty(classNameKey);
+    }
+  }
+
+  @Test
+  @DisplayName("enableEnginePlugin=false prevents creation of the auto-configured plugin and preprocessor beans")
+  void enableEnginePluginFalsePreventsAutoConfiguredPluginAndPreprocessorBeans() {
+    String key = "fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin";
+    System.setProperty(key, "false");
+    try (ConfigurableApplicationContext context =
+        runContext(new Class<?>[] {IntegrationTestApplication.class})) {
+      assertEquals(1, context.getBeansOfType(ScriptPreprocessorProperties.class).size());
+
+      ScriptPreprocessorProperties props = context.getBean(ScriptPreprocessorProperties.class);
+      assertFalse(props.isEnableEnginePlugin());
+
+      assertEquals(0, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+      assertEquals(0, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+    } finally {
+      System.clearProperty(key);
+    }
+  }
+
+  @Test
+  @DisplayName("User-defined ScriptPreprocessorPlugin backs off the auto-configured plugin bean")
+  void userDefinedScriptPreprocessorPluginBacksOffAutoConfiguredPluginBean() {
+    try (ConfigurableApplicationContext context =
+        runContext(new Class<?>[] {IntegrationTestApplication.class, CustomPluginConfiguration.class})) {
+      assertEquals(1, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+      assertSame(
+          context.getBean("customScriptPreprocessorPlugin"),
+          context.getBean(ScriptPreprocessorPlugin.class));
+
+      assertEquals(1, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+    }
+  }
+
+  @Test
+  @DisplayName("User-defined CamundaToFluxnovaRewritePreprocessor backs off the default preprocessor bean")
+  void userDefinedCamundaToFluxnovaRewritePreprocessorBacksOffDefaultBean() {
+    try (ConfigurableApplicationContext context =
+        runContext(
+            new Class<?>[] {IntegrationTestApplication.class, CustomDefaultPreprocessorConfiguration.class})) {
+      assertEquals(1, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+      CamundaToFluxnovaRewritePreprocessor preprocessor =
+          context.getBean(CamundaToFluxnovaRewritePreprocessor.class);
+
+      assertSame(
+          context.getBean("customCamundaToFluxnovaRewritePreprocessor"),
+          preprocessor);
+      assertEquals(
+          "org.camunda.bpm.runtime.MyFluxnovaTask",
+          preprocessor.process(requestWithScript("org.camunda.bpm.runtime.MyCamundaTask")));
+      assertEquals(1, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+    }
+  }
+
+  @SpringBootConfiguration
+  @EnableAutoConfiguration
+  static class IntegrationTestApplication {}
+
+  @Configuration(proxyBeanMethods = false)
+  static class CustomPluginConfiguration {
+
+    @Bean
+    ScriptPreprocessorPlugin customScriptPreprocessorPlugin() {
+      ScriptPreprocessorPlugin plugin = new ScriptPreprocessorPlugin();
+      plugin.setEnableDefaultCamundaToFluxnovaPreprocessor(false);
+      return plugin;
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class CustomDefaultPreprocessorConfiguration {
+
+    @Bean
+    CamundaToFluxnovaRewritePreprocessor customCamundaToFluxnovaRewritePreprocessor() {
+      return new CamundaToFluxnovaRewritePreprocessor(
+          new ScriptingConfigurationProperties(true, false, false, true, true));
+    }
+  }
+}

--- a/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorAutoConfigurationTest.java
+++ b/fluxnova-backward-compatibility-plugin/src/test/java/org/finos/fluxnova/plugin/preprocessor/spring/ScriptPreprocessorAutoConfigurationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.plugin.preprocessor.spring;
+
+import org.finos.fluxnova.plugin.ScriptPreprocessorPlugin;
+import org.finos.fluxnova.plugin.preprocessor.core.CamundaToFluxnovaRewritePreprocessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the {@link ScriptPreprocessorAutoConfiguration} Spring auto-configuration.
+ *
+ * <p>This class is the <strong>canonical {@code @ConfigurationProperties} binding contract</strong>
+ * for {@link ScriptPreprocessorProperties}: it verifies that all five properties are correctly
+ * bound from the classpath defaults and that they can be overridden via the Spring
+ * {@code Environment}.
+ *
+ * <p>Bean-creation conditions ({@code @ConditionalOnProperty} and
+ * {@code @ConditionalOnMissingBean}) are also covered here using
+ * {@link ApplicationContextRunner}, which avoids starting a full Spring Boot application context.
+ *
+ * <p>For end-to-end auto-configuration discovery (via
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}) and
+ * preprocessor output verification, see
+ * {@code ScriptPreprocessorAutoConfigurationIT}.
+ */
+@DisplayName("ScriptPreprocessorAutoConfiguration canonical ConfigurationProperties binding contract")
+class ScriptPreprocessorAutoConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner().withUserConfiguration(ScriptPreprocessorAutoConfiguration.class);
+
+  // -------------------------------------------------------------------------
+  // ConfigurationProperties binding assertions (canonical contract)
+  // -------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("ConfigurationProperties binding: binds defaults from script-preprocessor.properties")
+  void bindsScriptPreprocessorPropertiesDefaults() {
+    contextRunner.run(
+        context -> {
+          assertEquals(1, context.getBeansOfType(ScriptPreprocessorProperties.class).size());
+          ScriptPreprocessorProperties props = context.getBean(ScriptPreprocessorProperties.class);
+
+          assertTrue(props.isEnableEnginePlugin());
+          assertTrue(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+          assertTrue(props.isRewriteCamundaReferencesInRootPackage());
+          assertFalse(props.isRewriteCamundaReferencesInPackagePath());
+          assertFalse(props.isRewriteCamundaReferencesInClassName());
+        });
+  }
+
+  @Test
+  @DisplayName("ConfigurationProperties binding: application properties override classpath defaults")
+  void bindsScriptPreprocessorPropertiesOverrides() {
+    contextRunner
+        .withPropertyValues(
+            "fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin=true",
+            "fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled=false",
+            "fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInRootPackage=false",
+            "fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInPackagePath=true",
+            "fluxnova.bpm.plugin.script-preprocessing.rewriteCamundaReferencesInClassName=true")
+        .run(
+            context -> {
+              ScriptPreprocessorProperties props = context.getBean(ScriptPreprocessorProperties.class);
+
+              assertTrue(props.isEnableEnginePlugin());
+              assertFalse(props.isDefaultCamundaToFluxnovaPreprocessorEnabled());
+              assertFalse(props.isRewriteCamundaReferencesInRootPackage());
+              assertTrue(props.isRewriteCamundaReferencesInPackagePath());
+              assertTrue(props.isRewriteCamundaReferencesInClassName());
+            });
+  }
+
+  // -------------------------------------------------------------------------
+  // Bean-creation conditions gated by bound properties
+  // -------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("Creates plugin and default preprocessor beans when both enable flags are true")
+  void createsPluginAndDefaultPreprocessorBeansWhenEnabled() {
+    contextRunner.run(
+        context -> {
+          assertEquals(1, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+          assertEquals(1, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+        });
+  }
+
+  @Test
+  @DisplayName("Does not create plugin or preprocessor bean when enableEnginePlugin is false")
+  void doesNotCreateBeansWhenEnginePluginDisabled() {
+    contextRunner
+        .withPropertyValues("fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin=false")
+        .run(
+            context -> {
+              assertEquals(0, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+              assertEquals(0, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+            });
+  }
+
+  @Test
+  @DisplayName("Does not create beans when enableEnginePlugin=false even if default preprocessor is true")
+  void doesNotCreateBeansWhenMasterGateDisabledEvenIfDefaultPreprocessorEnabled() {
+    contextRunner
+        .withPropertyValues(
+            "fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin=false",
+            "fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled=true")
+        .run(
+            context -> {
+              assertEquals(0, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+              assertEquals(0, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+            });
+  }
+
+  @Test
+  @DisplayName("Creates plugin but not default preprocessor when default preprocessor flag is false")
+  void createsPluginWithoutDefaultPreprocessorWhenDisabled() {
+    contextRunner
+        .withPropertyValues(
+            "fluxnova.bpm.plugin.script-preprocessing.enableEnginePlugin=true",
+            "fluxnova.bpm.plugin.script-preprocessing.defaultCamundaToFluxnovaPreprocessorEnabled=false")
+        .run(
+            context -> {
+              assertEquals(1, context.getBeansOfType(ScriptPreprocessorPlugin.class).size());
+              assertEquals(0, context.getBeansOfType(CamundaToFluxnovaRewritePreprocessor.class).size());
+            });
+  }
+}
+


### PR DESCRIPTION
**Adds the initial implementation of the Fluxnova Backward Compatibility Plugin.**

- Provides seamless migration by rewriting Camunda references to Fluxnova equivalents at script execution time.
- Supports both Spring Boot auto-configuration and plain Java environments.
- Features robust configuration (property file, JVM, Spring) and chaining support.
- Includes documentation, integration tests, and unit tests.