### PR TITLE
ISSUE-12 - GHA pipeline impl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @finos/fluxnova-maintainers
+
+# Any changes to this CODEOWNERS file should be reviewed by finos-admins
+/.github/CODEOWNERS @finos/finos-admins

--- a/.github/actions/java-setup/action.yml
+++ b/.github/actions/java-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: 'temurin'
@@ -13,7 +13,7 @@ runs:
         server-password: ${{ env.CI_DEPLOY_PASSWORD }}
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-mvn-deps
       with:

--- a/.github/actions/java-setup/action.yml
+++ b/.github/actions/java-setup/action.yml
@@ -1,0 +1,29 @@
+name: "Java setup"
+description: "Common steps for Java setup"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 21
+        distribution: 'temurin'
+        server-id: ossrh
+        server-username: ${{ env.CI_DEPLOY_USERNAME }}
+        server-password: ${{ env.CI_DEPLOY_PASSWORD }}
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-mvn-deps
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Check Java version
+      shell: bash
+      run: java -version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Berlin
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+
+
+*
+
+## Related issues
+
+
+
+closes #

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -26,7 +26,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Java setup
         uses: ./.github/actions/java-setup

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -1,0 +1,40 @@
+name: Build Plugin project
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+  CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref == 'refs/heads/main' && format('ci-default-branch-{0}-{1}', github.sha, github.workflow) ||
+    format('ci-pr-{0}-{1}', github.ref, github.workflow) }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Java setup
+        uses: ./.github/actions/java-setup
+
+      - name: Build
+        if: github.ref != 'refs/heads/main'
+        run: mvn -B -e clean install
+
+      - name: Deploy
+        if: github.ref == 'refs/heads/main'
+        run: mvn -B -e clean deploy -s ./settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+# Workflow: Release and publish artifacts to Maven Central
+# Purpose: Builds, signs, and publishes Maven artifacts to Sonatype OSSRH, then tags the released version.
+# Prerequisites: pom.xml must be on a *-SNAPSHOT version.
+# Notes:
+#   - release/* branches: major version increment (e.g., 1.2.3-SNAPSHOT to 2.0.0-SNAPSHOT)
+#   - hotfix/* branches: minor version increment (e.g., 1.2.3-SNAPSHOT to 1.3.0-SNAPSHOT)
+
+name: "Release and publish artifacts to Maven Central"
+
+env:
+  CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+  CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+  CI_GPG_PASSPHRASE: ${{ secrets.CI_GPG_PASSPHRASE }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'release/*'
+      - 'hotfix/*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish-central:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
+          gpg-passphrase: CI_GPG_PASSPHRASE
+
+      - name: Configure git
+        run: |
+          git config --global committer.email "infra@finos.org"
+          git config --global committer.name "FINOS Admin"
+          git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global author.name "${GITHUB_ACTOR}"
+
+      - name: Download deps and plugins
+        run: mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -s ./settings.xml
+
+      - name: Extract version from pom.xml and compute next development version
+        run: |
+          currentVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          releaseVersion=${currentVersion%-SNAPSHOT}
+          echo "RELEASE_VERSION=${releaseVersion}" >> $GITHUB_ENV
+          TAG="v${releaseVersion}"
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Branch name: $BRANCH_NAME"
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          if [[ "$BRANCH_NAME" == release/* ]]; then
+            nextMajor=$((${a[0]} + 1))
+            developmentVersion="${nextMajor}.0.0-SNAPSHOT"
+            echo "Branch type: Release - Incrementing major version: ${releaseVersion} -> ${developmentVersion}"
+          elif [[ "$BRANCH_NAME" == hotfix/* ]]; then
+            currentMajor=${a[0]}
+            nextMinor=$((${a[1]} + 1))
+            developmentVersion="${currentMajor}.${nextMinor}.0-SNAPSHOT"
+            echo "Branch type: Hotfix - Incrementing minor version: ${releaseVersion} -> ${developmentVersion}"
+          fi
+          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
+
+      - name: Configure GitHub authentication for Maven Release Plugin
+        run: |
+          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Prepare release
+        run: |
+          mvn -B \
+            -DpreparationGoals=clean \
+            release:prepare \
+            -DreleaseVersion=${{ env.RELEASE_VERSION }} \
+            -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} \
+            -Dtag=${{ env.TAG }} \
+            -DautoVersionSubmodules=true \
+            -DinteractiveMode=false \
+            -P release
+
+      - name: Perform release
+        run: mvn -B release:perform -Prelease -DinteractiveMode=false

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
     <build>
@@ -107,4 +108,36 @@
             </plugins>
         </pluginManagement>
     </build>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.finos.fluxnova.bpm</groupId>
+    <parent>
+        <artifactId>fluxnova-parent</artifactId>
+        <groupId>org.finos.fluxnova.bpm</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>fluxnova-plugins</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Fluxnova Platform - engine plugins</name>
@@ -13,131 +17,27 @@
         <module>agentic</module>
     </modules>
     <properties>
-        <java.version>21</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependency Versions -->
         <spring-boot.version>3.5.8</spring-boot.version>
         <slf4j.version>2.0.9</slf4j.version>
         <junit.version>5.10.1</junit.version>
-
-        <!-- Plugin versions -->
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
-        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- Import Fluxnova BOM for version alignment -->
-            <dependency>
-                <groupId>org.finos.fluxnova.bpm</groupId>
-                <artifactId>fluxnova-bom</artifactId>
-                <version>2.0.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- Import Spring Boot BOM -->
+            <!-- Spring Boot BOM - manages all Spring Boot and Spring Framework versions -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.5.8</version>
+                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.fluxnova.bpm</groupId>
+                <artifactId>fluxnova-engine</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
         </dependencies>
     </dependencyManagement>
-    <build>
-        <pluginManagement>
-            <plugins>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven-compiler-plugin.version}</version>
-                    <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                        <encoding>${project.build.sourceEncoding}</encoding>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin.version}</version>
-                </plugin>
-
-                <!--
-                    flatten-maven-plugin
-                    Rewrites the published POM to remove the parent reference.
-                    Consumers see a clean standalone artifact with no internal
-                    hierarchy leaking out.
-                -->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>flatten-maven-plugin</artifactId>
-                    <version>${flatten-maven-plugin.version}</version>
-                    <configuration>
-                        <!--
-                            ossrh mode: strips parent, keeps deps, keeps
-                            description/url/licenses/devs for published artifacts.
-                        -->
-                        <flattenMode>ossrh</flattenMode>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>flatten</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>flatten</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>flatten-clean</id>
-                            <phase>clean</phase>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
-    </build>
-    <repositories>
-        <repository>
-            <id>central</id>
-            <name>Maven Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>ossrh-snapshots</id>
-            <name>Sonatype OSSRH Snapshots</name>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <name>Central Portal Snapshots</name>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,10 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.CI_DEPLOY_USERNAME}</username>
+            <password>${env.CI_DEPLOY_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
## Description

Adds GitHub Actions CI/CD pipeline configuration to `fluxnova-plugins`, modelled on the existing setup in `fluxnova-feel-scala`.

## Changes

* `.github/actions/java-setup/action.yml` - Reusable composite action: JDK 21 (Temurin), Maven dependency cache, Java version check
* `.github/workflows/build-maven.yml` - CI workflow: build on PRs, deploy to OSSRH on merge to `main`
* `.github/workflows/release.yml` - Release workflow: publishes to Maven Central from `release/*` (major bump) and `hotfix/*` (minor bump) branches
* `.github/dependabot.yml` - Daily dependency updates for Maven and GitHub Actions ecosystems
* `.github/CODEOWNERS` - Default owner `@finos/fluxnova-maintainers`, CODEOWNERS guarded by `@finos/finos-admins`
* `.github/pull_request_template.md` - Standard PR template with description and related issues sections

## Related issues

closes #12