### PR TITLE
MCP Process Start Event with configurable return parameters

### DIFF
--- a/agentic/README.md
+++ b/agentic/README.md
@@ -91,11 +91,18 @@ spring.ai.mcp.server.type=sync
           <mcp:parameter paramName="customerName" paramType="string"/>
           <mcp:parameter paramName="customerId"   paramType="string"/>
         </mcp:parameters>
+        <mcp:returnVariables>
+            <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="String" />
+            <mcp:returnVariable paramName="myResponseProcessVariable2" paramType="String" />
+        </mcp:returnVariables>
+      </extensionElements>
       </bpmn:extensionElements>
     </bpmn:startEvent>
   </bpmn:process>
 </bpmn:definitions>
 ```
+See [MCP Process Start Event](mcp-process-start-event/README.md)
+for full syntax documentation
 
 #### 4. Compile and build
 

--- a/agentic/mcp-process-start-event/README.md
+++ b/agentic/mcp-process-start-event/README.md
@@ -12,7 +12,8 @@ A Fluxnova `ProcessEnginePlugin` that scans BPMN processes for MCP-annotated sta
 
 ## Prerequisites
 
-`mcp-server-plugin` must be on the classpath (and its `ToolRegistry` bean present) for this plugin to activate.
+- `mcp-server-plugin` must be on the classpath (and its `ToolRegistry` bean present) for this plugin to activate.
+- **Jackson (`jackson-databind`)** is required at runtime for variable serialization. In Spring Boot deployments this is automatically available. For non-Spring-Boot Fluxnova deployments, you must add `jackson-databind` to the runtime classpath explicitly.
 
 ## Installation
 
@@ -86,14 +87,15 @@ Declare any optional output parameters inside `extensionElements`:
 ```xml
 <extensionElements>
   <mcp:returnVariables>
-    <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="String" />
+    <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="string" />
   </mcp:returnVariables>
 </extensionElements>
 ```
 
-- Note that `paramName` is case sensitive. 
+- Note that `paramName` is case sensitive.
+- The `paramType` attribute on return variables is **metadata only** — it documents the expected type for consumers (e.g., LLM clients) but is not enforced at runtime. The actual serialization is determined by the Java type of the process variable (see supported types below).
 - Any variable specified that is available in process at commit point (Asynch before/after or natural commit point like a user task or timer) will be returned at response.
-- It is the responsibility of the process designer to ensure that the response variables are suitable for LLM consumption as well as reasonable size limits. 
+- It is the responsibility of the process designer to ensure that the response variables are suitable for LLM consumption as well as reasonable size limits.
 
 Supported output `paramType` values:
 
@@ -127,8 +129,8 @@ Supported output `paramType` values:
           <mcp:parameter paramName="description" paramType="string"/>
         </mcp:parameters>
         <mcp:returnVariables>
-          <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="String" />
-          <mcp:returnVariable paramName="myResponseProcessVariable2" paramType="String" />
+          <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="string" />
+          <mcp:returnVariable paramName="myResponseProcessVariable2" paramType="string" />
         </mcp:returnVariables>
       </extensionElements>
     </startEvent>

--- a/agentic/mcp-process-start-event/README.md
+++ b/agentic/mcp-process-start-event/README.md
@@ -8,6 +8,7 @@ A Fluxnova `ProcessEnginePlugin` that scans BPMN processes for MCP-annotated sta
 - Runs a startup scanner that registers tools for processes that were **already deployed** before the application started
 - Translates BPMN start event metadata into `ToolConfig` objects and registers them in the `ToolRegistry`
 - Starts a Fluxnova process instance when an MCP client invokes a tool
+- Returns specified return parameters available up to the first Asynch before/after or natural commit point (like a user task or timer)
 
 ## Prerequisites
 
@@ -79,12 +80,35 @@ Declare input parameters inside `extensionElements`:
   </mcp:parameters>
 </extensionElements>
 ```
+Supported input `paramType` values: `string`, `number`, `boolean`, `object`, `array`
 
-Supported `paramType` values: `string`, `number`, `boolean`, `object`, `array`
+Declare any optional output parameters inside `extensionElements`:
+```xml
+<extensionElements>
+  <mcp:returnVariables>
+    <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="String" />
+  </mcp:returnVariables>
+</extensionElements>
+```
+
+- Note that `paramName` is case sensitive. 
+- Any variable specified that is available in process at commit point (Asynch before/after or natural commit point like a user task or timer) will be returned at response.
+- It is the responsibility of the process designer to ensure that the response variables are suitable for LLM consumption as well as reasonable size limits. 
+
+Supported output `paramType` values:
+
+- `string`:  String values
+- `number`: Integer, Long, Date (serialized as epoch milliseconds), and other numeric types if serializable by Spin
+- `boolean`: Boolean values
+- `object`: Map<String,Object>, Spin JSON objects, and Java POJOs serializable by Spin
+- `array`: JSON arrays, List/Collection types serializable by Spin
+
+
+
 
 ## Usage Examples
 
-### Example 1 — Simple process trigger with business key
+### Example 1 — Simple process trigger with business key with output parameters
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -102,6 +126,10 @@ Supported `paramType` values: `string`, `number`, `boolean`, `object`, `array`
           <mcp:parameter paramName="amount"      paramType="number"/>
           <mcp:parameter paramName="description" paramType="string"/>
         </mcp:parameters>
+        <mcp:returnVariables>
+          <mcp:returnVariable paramName="myResponseProcessVariable1" paramType="String" />
+          <mcp:returnVariable paramName="myResponseProcessVariable2" paramType="String" />
+        </mcp:returnVariables>
       </extensionElements>
     </startEvent>
     <!-- ... rest of process ... -->

--- a/agentic/mcp-process-start-event/pom.xml
+++ b/agentic/mcp-process-start-event/pom.xml
@@ -33,7 +33,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Jackson (provided by Spring Boot at runtime) -->
+        <!-- Jackson (provided by Spring Boot at runtime; must be added explicitly for non-Spring-Boot deployments) -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/agentic/mcp-process-start-event/pom.xml
+++ b/agentic/mcp-process-start-event/pom.xml
@@ -33,6 +33,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Jackson (provided by Spring Boot at runtime) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/McpParseListener.java
+++ b/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/McpParseListener.java
@@ -25,7 +25,6 @@ import java.util.Set;
  * <p>
  * The listener delegates to:
  * <ul>
- *   <li>{@link BpmnStartEventToolExtractor} - to extract MCP metadata from BPMN XML</li>
  *   <li>{@link ToolFactory} - to create and register the tool with the {@code ToolRegistry}</li>
  * </ul>
  * </p>
@@ -92,7 +91,6 @@ public class McpParseListener extends AbstractBpmnParseListener {
                     "MCP - Deployment validation failed: duplicate return variable name '%s' " +
                     "in start event '%s' of process '%s'. Each return variable must have a unique name.",
                     returnVar.name(), startEventId, toolDefinition.processKey());
-                LOG.error(errorMsg);
                 throw new RuntimeException(errorMsg);
             }
             seenNames.add(returnVar.name());

--- a/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializer.java
+++ b/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializer.java
@@ -6,9 +6,12 @@ import org.finos.fluxnova.ai.mcp.process.model.ToolParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -70,7 +73,8 @@ public class VariableSerializer {
      *   <li>null: returned as null</li>
      *   <li>String, Integer, Long, Boolean: returned as-is</li>
      *   <li>Date: returned as timestamp in milliseconds</li>
-     *   <li>Map: returned as-is (already JSON-compatible)</li>
+     *   <li>Map: recursively normalized (nested values are also normalized)</li>
+     *   <li>Collection/List: recursively normalized (elements are also normalized)</li>
      *   <li>Spin JSON objects: unwrapped via reflection, parsed with Jackson</li>
      *   <li>Other objects: serialized via Jackson (round-trip to Map/List/primitive)</li>
      * </ul>
@@ -94,9 +98,22 @@ public class VariableSerializer {
             return date.getTime();
         }
 
-        // Already a Map → JSON-compatible structure
-        if (value instanceof Map<?, ?>) {
-            return value;
+        // Map → recursively normalize values
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                normalized.put(String.valueOf(entry.getKey()), normalize(entry.getValue()));
+            }
+            return normalized;
+        }
+
+        // Collection/List → recursively normalize elements
+        if (value instanceof Collection<?> collection) {
+            List<Object> normalized = new ArrayList<>(collection.size());
+            for (Object element : collection) {
+                normalized.add(normalize(element));
+            }
+            return normalized;
         }
 
         // Spin JSON → unwrap to string → parse with Jackson

--- a/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializer.java
+++ b/agentic/mcp-process-start-event/src/main/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializer.java
@@ -1,39 +1,38 @@
 package org.finos.fluxnova.ai.mcp.process.engine;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.finos.fluxnova.ai.mcp.process.model.ToolDefinition;
 import org.finos.fluxnova.ai.mcp.process.model.ToolParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
  * Handles serialization and collection of process variables for MCP responses.
- * 
+ *
  * Responsible for:
  * - Collecting configured return variables from process-scope
- * - Serializing variables to JSON-compatible format
- * - Parsing JSON strings to structured objects
+ * - Normalizing variable values to JSON-compatible types (Map, List, String, Number, Boolean)
  * - Converting between variable map types (VariableMap to HashMap)
- * 
- * This class ensures that return variables are properly formatted and that
- * individual serialization failures do not prevent other variables from being included.
+ *
+ * JSON parsing and serialization is delegated to Jackson ObjectMapper.
+ * Spin JSON objects are unwrapped via reflection (Spin is an optional runtime dependency).
  */
 public class VariableSerializer {
     private static final Logger LOG = LoggerFactory.getLogger(VariableSerializer.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Collects configured return variables from pre-captured process-scope variables.
      *
      * Return variables are resolved exclusively from the pre-captured variables map
-     * that was obtained at the first async boundary. Execution-local variables are
-     * not considered. If a configured variable does not exist, it is included with
-     * a null value. Individual variable retrieval or serialization failures do not
-     * prevent other variables from being collected.
+     * that was obtained at the first async boundary. If a configured variable does
+     * not exist, it is included with a null value. Individual variable retrieval or
+     * serialization failures do not prevent other variables from being collected.
      *
      * @param definition the tool definition with return variable configuration
      * @param capturedVariablesObj the pre-captured process-scope variables (VariableMap or Map)
@@ -41,8 +40,6 @@ public class VariableSerializer {
      */
     public Map<String, Object> collectReturnVariables(ToolDefinition definition, Object capturedVariablesObj) {
         Map<String, Object> values = new LinkedHashMap<>();
-
-        // Convert to a Map if needed (handles VariableMap type from Fluxnova)
         Map<String, Object> capturedVariables = convertToMap(capturedVariablesObj);
 
         LOG.debug("collectReturnVariables: capturedVariables = {}", capturedVariables);
@@ -51,13 +48,10 @@ public class VariableSerializer {
         for (ToolParameter returnVar : definition.returnVariables()) {
             try {
                 Object value = capturedVariables.get(returnVar.name());
-                LOG.debug("collectReturnVariables: getting {} = {} ", returnVar.name(), value);
-                Object serialized = serializeVariable(value, returnVar.type());
-
-                LOG.debug("collectReturnVariables: after serialize {} = {} ", returnVar.name(), serialized);
-                values.put(returnVar.name(), serialized);
+                Object normalized = normalize(value);
+                values.put(returnVar.name(), normalized);
                 LOG.debug("MCP - Collected return variable '{}': {}",
-                        returnVar.name(), serialized != null ? "value set" : "null");
+                        returnVar.name(), normalized != null ? "value set" : "null");
             } catch (Exception e) {
                 LOG.warn("MCP - Failed to collect return variable '{}', setting to null",
                         returnVar.name(), e);
@@ -69,477 +63,142 @@ public class VariableSerializer {
     }
 
     /**
-     * Serializes a variable value to JSON-compatible format using Fluxnova/Spin.
+     * Normalizes a variable value to a JSON-compatible type.
      *
      * <h2>Supported Types</h2>
-     *
      * <ul>
-     *   <li>String: Returned as-is</li>
-     *   <li>Integer, Long: Returned as numeric value</li>
-     *   <li>Boolean: Returned as boolean value</li>
-     *   <li>Date: Returned as timestamp in milliseconds</li>
-     *   <li>JSON objects/arrays: Returned as structured JSON</li>
-     *   <li>Spin JSON: Unwrapped and returned as structured JSON</li>
-     *   <li>Serializable Objects: Serialized via Spin.JSON()</li>
-     *   <li>Other types: Serialized via toString() or null on failure</li>
+     *   <li>null: returned as null</li>
+     *   <li>String, Integer, Long, Boolean: returned as-is</li>
+     *   <li>Date: returned as timestamp in milliseconds</li>
+     *   <li>Map: returned as-is (already JSON-compatible)</li>
+     *   <li>Spin JSON objects: unwrapped via reflection, parsed with Jackson</li>
+     *   <li>Other objects: serialized via Jackson (round-trip to Map/List/primitive)</li>
      * </ul>
      *
-     * <h2>JSON Structure Preservation</h2>
-     *
-     * JSON values are returned as structured objects or arrays, not escaped
-     * strings. For example, a JSON object {@code {"id":"123","name":"John"}}
-     * is returned as a structured JSON object, not as an escaped string.
-     *
-     * <h2>Error Handling</h2>
-     *
-     * Individual serialization failures do not cause exceptions. Instead,
-     * the variable is included in the response with a null value, and a
-     * warning is logged.
-     *
-     * @param value the variable value to serialize, may be null
-     * @param typeHint optional type hint from the parameter definition
-     * @return a JSON-compatible object suitable for response inclusion,
-     *         or null if serialization failed or value was null
+     * @param value the variable value to normalize, may be null
+     * @return a JSON-compatible object, or null if normalization failed
      */
-    public Object serializeVariable(Object value, String typeHint) {
+    Object normalize(Object value) {
         if (value == null) {
             return null;
         }
 
+        // Primitives and String pass through directly
+        if (value instanceof String || value instanceof Integer ||
+            value instanceof Long || value instanceof Boolean) {
+            return value;
+        }
+
+        // Date → epoch millis
+        if (value instanceof Date date) {
+            return date.getTime();
+        }
+
+        // Already a Map → JSON-compatible structure
+        if (value instanceof Map<?, ?>) {
+            return value;
+        }
+
+        // Spin JSON → unwrap to string → parse with Jackson
+        if (isSpinJson(value)) {
+            return unwrapSpinJson(value);
+        }
+
+        // Anything else → Jackson round-trip to get Map/List/primitive
         try {
-            // String, Integer, Long, Boolean types
-            if (value instanceof String || value instanceof Integer ||
-                value instanceof Long || value instanceof Boolean) {
-                return value;
-            }
-
-            // Date handling
-            if (value instanceof java.util.Date) {
-                return ((java.util.Date) value).getTime();
-            }
-
-            // Spin JSON - unwrap to native JSON structure
-            if (isSpinJson(value)) {
-                return unwrapSpinJson(value);
-            }
-
-            // JSON objects (if value is already parsed JSON)
-            if (isJsonObject(value)) {
-                return value;  // Return as structured JSON, not escaped string
-            }
-
-            // Java objects - attempt Spin serialization
-            if (isSpinAvailable()) {
-                return serializeWithSpin(value);
-            }
-
-            // Fallback: try toString() for simple objects
-            return value.toString();
-
+            String json = MAPPER.writeValueAsString(value);
+            return MAPPER.readValue(json, Object.class);
         } catch (Exception e) {
-            LOG.warn("MCP - Failed to serialize variable of type {}, returning null: {}",
+            LOG.debug("MCP - Jackson normalization failed for type {}, using toString: {}",
                     value.getClass().getName(), e.getMessage());
-            return null;
+            return value.toString();
         }
     }
 
     /**
-     * Parses a JSON string back to a structured object (Map/List).
+     * Parses a JSON string to a structured object (Map or List).
      *
-     * Converts JSON string representations to structured Java objects
-     * (Map for JSON objects, List for JSON arrays) for proper JSON response
-     * formatting. Returns structured objects rather than escaped strings
-     * to match the documented behavior that "JSON values are returned as
-     * structured objects or arrays, not escaped strings."
+     * Uses Jackson ObjectMapper for parsing. Returns structured objects rather
+     * than escaped strings. If parsing fails, returns the original string.
      *
      * @param jsonString the JSON string to parse
-     * @return the parsed JSON object structure as Map/List, or the string if parsing fails
+     * @return parsed Map/List, or the original string if not valid JSON
      */
     public Object parseJsonString(String jsonString) {
         if (jsonString == null || jsonString.isBlank()) {
             return jsonString;
         }
-        
+
         try {
             String trimmed = jsonString.trim();
-            
-            // Parse JSON object: {...}
-            if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-                return parseJsonObject(trimmed);
+            if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+                return MAPPER.readValue(trimmed, Object.class);
             }
-            
-            // Parse JSON array: [...]
-            if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-                return parseJsonArray(trimmed);
-            }
-            
-            // Not JSON, return as-is
             return jsonString;
         } catch (Exception e) {
             LOG.debug("MCP - Failed to parse JSON string, returning as-is: {}", e.getMessage());
-            return jsonString;  // Return as-is if parsing fails
+            return jsonString;
         }
     }
 
     /**
-     * Parses a JSON object string into a Map.
-     * Simple recursive descent parser supporting nested objects and arrays.
-     * 
-     * @param jsonObject the JSON object string
-     * @return parsed Map
-     */
-    private Map<String, Object> parseJsonObject(String jsonObject) {
-        Map<String, Object> result = new LinkedHashMap<>();
-        String content = jsonObject.substring(1, jsonObject.length() - 1).trim();
-        
-        if (content.isEmpty()) {
-            return result;
-        }
-        
-        // Split by commas that are not inside nested structures or strings
-        int depth = 0;
-        int start = 0;
-        
-        for (int i = 0; i < content.length(); i++) {
-            char ch = content.charAt(i);
-            
-            if ((ch == '{' || ch == '[') && isNotInString(content, i)) {
-                depth++;
-            } else if ((ch == '}' || ch == ']') && isNotInString(content, i)) {
-                depth--;
-            } else if (ch == ',' && depth == 0 && isNotInString(content, i)) {
-                // Process key-value pair
-                String pair = content.substring(start, i).trim();
-                processJsonPair(result, pair);
-                start = i + 1;
-            }
-        }
-        
-        // Process last pair
-        if (start < content.length()) {
-            String pair = content.substring(start).trim();
-            processJsonPair(result, pair);
-        }
-        
-        return result;
-    }
-
-    /**
-     * Parses a JSON array string into a List.
-     * 
-     * @param jsonArray the JSON array string
-     * @return parsed List
-     */
-    private List<Object> parseJsonArray(String jsonArray) {
-        List<Object> result = new ArrayList<>();
-        String content = jsonArray.substring(1, jsonArray.length() - 1).trim();
-        
-        if (content.isEmpty()) {
-            return result;
-        }
-        
-        int depth = 0;
-        int start = 0;
-        
-        for (int i = 0; i < content.length(); i++) {
-            char ch = content.charAt(i);
-            
-            if ((ch == '{' || ch == '[') && isNotInString(content, i)) {
-                depth++;
-            } else if ((ch == '}' || ch == ']') && isNotInString(content, i)) {
-                depth--;
-            } else if ((ch == ',' || i == content.length() - 1) && depth == 0 && isNotInString(content, i)) {
-                int end = (i == content.length() - 1 && ch != ',') ? i + 1 : i;
-                String valueStr = content.substring(start, end).trim();
-                if (!valueStr.isEmpty()) {
-                    result.add(parseJsonValue(valueStr));
-                }
-                start = i + 1;
-            }
-        }
-        
-        return result;
-    }
-
-    /**
-     * Parses a single JSON value (string, number, boolean, null, object, or array).
-     * 
-     * @param valueStr the JSON value string
-     * @return parsed value
-     */
-    private Object parseJsonValue(String valueStr) {
-        valueStr = valueStr.trim();
-        
-        if (valueStr.isEmpty()) {
-            return null;
-        }
-        
-        // null
-        if ("null".equals(valueStr)) {
-            return null;
-        }
-        
-        // boolean
-        if ("true".equals(valueStr)) {
-            return true;
-        }
-        if ("false".equals(valueStr)) {
-            return false;
-        }
-        
-        // number
-        if (valueStr.matches("-?\\d+(\\.\\d+)?([eE][+-]?\\d+)?")) {
-            try {
-                if (valueStr.contains(".") || valueStr.contains("e") || valueStr.contains("E")) {
-                    return Double.parseDouble(valueStr);
-                } else {
-                    return Long.parseLong(valueStr);
-                }
-            } catch (NumberFormatException e) {
-                return valueStr;
-            }
-        }
-        
-        // string
-        if (valueStr.startsWith("\"") && valueStr.endsWith("\"")) {
-            return unquoteString(valueStr);
-        }
-        
-        // object
-        if (valueStr.startsWith("{") && valueStr.endsWith("}")) {
-            return parseJsonObject(valueStr);
-        }
-        
-        // array
-        if (valueStr.startsWith("[") && valueStr.endsWith("]")) {
-            return parseJsonArray(valueStr);
-        }
-        
-        // unknown
-        return valueStr;
-    }
-
-    /**
-     * Processes a single "key": value pair from JSON.
-     */
-    private void processJsonPair(Map<String, Object> map, String pair) {
-        int colonIndex = findColonIndex(pair);
-        if (colonIndex > 0) {
-            String keyPart = pair.substring(0, colonIndex).trim();
-            String valuePart = pair.substring(colonIndex + 1).trim();
-            
-            String key = unquoteString(keyPart);
-            Object value = parseJsonValue(valuePart);
-            map.put(key, value);
-        }
-    }
-
-    /**
-     * Finds the colon that separates key from value (not inside strings/brackets).
-     */
-    private int findColonIndex(String pair) {
-        int depth = 0;
-        for (int i = 0; i < pair.length(); i++) {
-            char ch = pair.charAt(i);
-            if ((ch == '{' || ch == '[') && isNotInString(pair, i)) {
-                depth++;
-            } else if ((ch == '}' || ch == ']') && isNotInString(pair, i)) {
-                depth--;
-            } else if (ch == ':' && depth == 0 && isNotInString(pair, i)) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * Checks if a character position is inside a JSON string (not escaped).
-     * Correctly handles escaped backslashes by counting consecutive backslashes
-     * before a quote to determine if the quote itself is escaped.
-     * 
-     * @param str the string to check
-     * @param pos the position to check
-     * @return true if position is inside an unescaped string
-     */
-    private boolean isNotInString(String str, int pos) {
-        boolean inString = false;
-        for (int i = 0; i < pos; i++) {
-            if (str.charAt(i) == '"' && !isEscaped(str, i)) {
-                inString = !inString;
-            }
-        }
-        return !inString;
-    }
-
-    /**
-     * Determines if a quote character at the given position is escaped by counting
-     * the number of consecutive backslashes before it. An odd number of backslashes
-     * means the quote is escaped; an even number means it is not.
-     * 
-     * Examples:
-     * - "text\"quote" → position of \" has 1 backslash → escaped (true)
-     * - "path\\" → position of closing " has 2 backslashes → not escaped (false)
-     * - "mixed\\\"quoted" → position of \" has 3 backslashes → escaped (true)
-     * 
-     * @param str the string to check
-     * @param pos the position of the quote to check
-     * @return true if the quote is escaped, false otherwise
-     */
-    private boolean isEscaped(String str, int pos) {
-        if (pos == 0) return false;
-        int backslashCount = 0;
-        for (int i = pos - 1; i >= 0 && str.charAt(i) == '\\'; i--) {
-            backslashCount++;
-        }
-        return backslashCount % 2 == 1;
-    }
-
-    /**
-     * Removes quotes from a JSON string value and unescapes special characters.
-     * 
-     * @param quotedStr the quoted string
-     * @return unquoted string
-     */
-    private String unquoteString(String quotedStr) {
-        if (quotedStr.startsWith("\"") && quotedStr.endsWith("\"")) {
-            String unquoted = quotedStr.substring(1, quotedStr.length() - 1);
-            // Unescape common JSON escape sequences
-            unquoted = unquoted.replace("\\\"", "\"");
-            unquoted = unquoted.replace("\\\\", "\\");
-            unquoted = unquoted.replace("\\n", "\n");
-            unquoted = unquoted.replace("\\r", "\r");
-            unquoted = unquoted.replace("\\t", "\t");
-            return unquoted;
-        }
-        return quotedStr;
-    }
-
-    /**
-     * Checks if a value is a Spin JSON object.
-     *
-     * @param value the value to check
-     * @return true if value is a Spin JSON object, false otherwise
-     */
-    private boolean isSpinJson(Object value) {
-        // Check if value is org.finos.fluxnova.spin.json.SpinJsonObject or similar
-        return value != null && value.getClass().getName()
-                .startsWith("org.finos.fluxnova.spin.json.");
-    }
-
-    /**
-     * Unwraps a Spin JSON object to extract the underlying JSON structure.
-     *
-     * @param spinJsonValue the Spin JSON value to unwrap
-     * @return the underlying JSON structure as a parsed object, or null if unwrapping fails
-     */
-    private Object unwrapSpinJson(Object spinJsonValue) {
-        // Extract underlying JSON from Spin wrapper
-        try {
-            // Spin JSON has methods like toJSON(), toString(), etc.
-            java.lang.reflect.Method toJsonMethod = spinJsonValue.getClass().getMethod("toJSON");
-            String jsonString = (String) toJsonMethod.invoke(spinJsonValue);
-            // Parse back to structured object (not escaped string)
-            return parseJsonString(jsonString);
-        } catch (Exception e) {
-            LOG.warn("MCP - Failed to unwrap Spin JSON: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * Checks if a value is already a JSON-compatible Map structure.
-     *
-     * @param value the value to check
-     * @return true if value is a Map, false otherwise
-     */
-    private boolean isJsonObject(Object value) {
-        // Check if already a JSON-compatible Map structure
-        return value instanceof java.util.Map;
-    }
-
-    /**
-     * Checks if the Spin library is available on the classpath.
-     *
-     * @return true if Spin is available, false otherwise
-     */
-    private boolean isSpinAvailable() {
-        try {
-            Class.forName("org.finos.fluxnova.spin.Spin");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
-
-    /**
-     * Serializes a Java object to JSON using Spin.
-     *
-     * @param value the object to serialize
-     * @return the serialized JSON object structure, or null if serialization fails
-     */
-    private Object serializeWithSpin(Object value) {
-        // Use Fluxnova Spin for JSON serialization
-        try {
-            // Implementation using org.finos.fluxnova.spin.Spin.JSON()
-            // Spin.JSON(value).toString() -> JSON string
-            // Parse back to structured object for JSON response
-            Class<?> spinClass = Class.forName("org.finos.fluxnova.spin.Spin");
-            java.lang.reflect.Method jsonMethod = spinClass.getMethod("JSON", Object.class);
-            Object spinJson = jsonMethod.invoke(null, value);
-            java.lang.reflect.Method toStringMethod = spinJson.getClass().getMethod("toString");
-            String jsonString = (String) toStringMethod.invoke(spinJson);
-            return parseJsonString(jsonString);
-        } catch (Exception e) {
-            LOG.warn("MCP - Spin serialization failed: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * Converts VariableMap (or any Map-like object) to a standard Map<String, Object>.
-     * Handles both VariableMap from the Fluxnova framework and mock HashMap objects.
+     * Converts VariableMap (or any Map-like object) to a standard Map.
+     * Handles both VariableMap from the Fluxnova framework and standard HashMap objects.
      *
      * @param variablesObj the variables object (could be VariableMap or HashMap)
-     * @return a Map<String, Object> representing the variables
+     * @return a Map representing the variables, never null
      */
+    @SuppressWarnings("unchecked")
     public Map<String, Object> convertToMap(Object variablesObj) {
-
         if (variablesObj == null) {
             LOG.debug("convertToMap: input is null, returning empty map");
             return new HashMap<>();
         }
 
-        // If it's already a Map, convert entries to a new HashMap
-        if (variablesObj instanceof java.util.Map) {
+        if (variablesObj instanceof Map<?, ?> map) {
             LOG.debug("convertToMap: is instanceof Map");
-            @SuppressWarnings("unchecked")
-            java.util.Map<String, Object> varMap = (java.util.Map<String, Object>) variablesObj;
-            LOG.debug("convertToMap: varMap = {}", varMap);
-            Map<String, Object> result = new HashMap<>(varMap);
-            LOG.debug("convertToMap: created new HashMap = {}", result);
-            return result;
+            return new HashMap<>((Map<String, Object>) map);
         }
 
         LOG.debug("convertToMap: is NOT instanceof Map, trying entrySet()");
 
-        // If VariableMap-like object with a way to get entries
+        // Reflection fallback for VariableMap-like objects
         try {
-            // Try to invoke entrySet() method (common to Map interface)
             java.lang.reflect.Method entrySetMethod = variablesObj.getClass().getMethod("entrySet");
             @SuppressWarnings("unchecked")
-            java.util.Set<java.util.Map.Entry<String, Object>> entries =
-                (java.util.Set<java.util.Map.Entry<String, Object>>) entrySetMethod.invoke(variablesObj);
+            java.util.Set<Map.Entry<String, Object>> entries =
+                (java.util.Set<Map.Entry<String, Object>>) entrySetMethod.invoke(variablesObj);
 
             Map<String, Object> result = new HashMap<>();
-            for (java.util.Map.Entry<String, Object> entry : entries) {
+            for (Map.Entry<String, Object> entry : entries) {
                 result.put(entry.getKey(), entry.getValue());
             }
             LOG.debug("convertToMap: created from entrySet = {}", result);
             return result;
         } catch (Exception e) {
             LOG.warn("MCP - Failed to convert variables object to Map: {}", e.getMessage());
-            LOG.debug("convertToMap - exception = {}", e);
             return new HashMap<>();
+        }
+    }
+
+    /**
+     * Checks if a value is a Spin JSON object (runtime detection via class name).
+     */
+    private boolean isSpinJson(Object value) {
+        return value.getClass().getName().startsWith("org.finos.fluxnova.spin.json.");
+    }
+
+    /**
+     * Unwraps a Spin JSON object by extracting its string representation and parsing with Jackson.
+     */
+    private Object unwrapSpinJson(Object spinJsonValue) {
+        try {
+            java.lang.reflect.Method toStringMethod = spinJsonValue.getClass().getMethod("toString");
+            String jsonString = (String) toStringMethod.invoke(spinJsonValue);
+            return parseJsonString(jsonString);
+        } catch (Exception e) {
+            LOG.warn("MCP - Failed to unwrap Spin JSON: {}", e.getMessage());
+            return null;
         }
     }
 }

--- a/agentic/mcp-process-start-event/src/test/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializerTest.java
+++ b/agentic/mcp-process-start-event/src/test/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializerTest.java
@@ -99,7 +99,72 @@ class VariableSerializerTest {
         }
 
         @Test
-        @DisplayName("Empty Map is preserved")
+        @DisplayName("Map with nested Date values normalizes recursively")
+        void mapWithNestedDateValues() {
+            Date date = new Date(1700000000000L);
+            Map<String, Object> value = new HashMap<>();
+            value.put("createdAt", date);
+            value.put("name", "test");
+
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> resultMap = (Map<?, ?>) result;
+            assertEquals(1700000000000L, resultMap.get("createdAt"));
+            assertEquals("test", resultMap.get("name"));
+        }
+
+        @Test
+        @DisplayName("Map with deeply nested non-primitive values normalizes recursively")
+        void mapWithDeeplyNestedNonPrimitives() {
+            Date innerDate = new Date(1600000000000L);
+            Map<String, Object> innerMap = new HashMap<>();
+            innerMap.put("timestamp", innerDate);
+            innerMap.put("count", 42);
+
+            Map<String, Object> outerMap = new HashMap<>();
+            outerMap.put("nested", innerMap);
+            outerMap.put("label", "outer");
+
+            Object result = serializer.normalize(outerMap);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> resultOuter = (Map<?, ?>) result;
+            assertEquals("outer", resultOuter.get("label"));
+
+            assertInstanceOf(Map.class, resultOuter.get("nested"));
+            Map<?, ?> resultInner = (Map<?, ?>) resultOuter.get("nested");
+            assertEquals(1600000000000L, resultInner.get("timestamp"));
+            assertEquals(42, resultInner.get("count"));
+        }
+
+        @Test
+        @DisplayName("Map with List containing non-primitives normalizes recursively")
+        void mapWithListContainingNonPrimitives() {
+            Date date1 = new Date(1500000000000L);
+            Date date2 = new Date(1600000000000L);
+            Map<String, Object> value = new HashMap<>();
+            value.put("dates", List.of(date1, date2));
+            value.put("name", "schedule");
+
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> resultMap = (Map<?, ?>) result;
+            assertEquals("schedule", resultMap.get("name"));
+
+            assertInstanceOf(List.class, resultMap.get("dates"));
+            List<?> dates = (List<?>) resultMap.get("dates");
+            assertEquals(2, dates.size());
+            assertEquals(1500000000000L, dates.get(0));
+            assertEquals(1600000000000L, dates.get(1));
+        }
+
+        @Test
+        @DisplayName("Empty Map is preserved after recursive normalization")
         void emptyMapValue() {
             Map<String, Object> value = new HashMap<>();
             Object result = serializer.normalize(value);

--- a/agentic/mcp-process-start-event/src/test/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializerTest.java
+++ b/agentic/mcp-process-start-event/src/test/java/org/finos/fluxnova/ai/mcp/process/engine/VariableSerializerTest.java
@@ -4,9 +4,9 @@ import org.finos.fluxnova.ai.mcp.process.model.ToolDefinition;
 import org.finos.fluxnova.ai.mcp.process.model.ToolParameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -24,496 +24,590 @@ class VariableSerializerTest {
         serializer = new VariableSerializer();
     }
 
-    // ===================== Tests for serializeVariable method =====================
+    // ===================== Tests for normalize method =====================
 
-    @DisplayName("serializeVariable: null value should return null")
-    @Test
-    void serializeVariableNullValue() throws Exception {
-        Object result = invokeSerializeVariable(null, null);
-        assertNull(result);
-    }
+    @Nested
+    @DisplayName("normalize")
+    class NormalizeTests {
 
-    @DisplayName("serializeVariable: String should be returned as-is")
-    @Test
-    void serializeVariableString() throws Exception {
-        String value = "test string";
-        Object result = invokeSerializeVariable(value, null);
-        assertEquals("test string", result);
-    }
-
-    @DisplayName("serializeVariable: Integer should be returned as-is")
-    @Test
-    void serializeVariableInteger() throws Exception {
-        Integer value = 42;
-        Object result = invokeSerializeVariable(value, null);
-        assertEquals(42, result);
-    }
-
-    @DisplayName("serializeVariable: Long should be returned as-is")
-    @Test
-    void serializeVariableLong() throws Exception {
-        Long value = 999L;
-        Object result = invokeSerializeVariable(value, null);
-        assertEquals(999L, result);
-    }
-
-    @DisplayName("serializeVariable: Boolean should be returned as-is")
-    @Test
-    void serializeVariableBoolean() throws Exception {
-        Boolean value = true;
-        Object result = invokeSerializeVariable(value, null);
-        assertEquals(true, result);
-    }
-
-    @DisplayName("serializeVariable: Date should be returned as timestamp in milliseconds")
-    @Test
-    void serializeVariableDate() throws Exception {
-        Date date = new Date(1000000000000L);
-        Object result = invokeSerializeVariable(date, null);
-        assertEquals(1000000000000L, result);
-    }
-
-    @DisplayName("serializeVariable: Map should be returned as structured JSON (not escaped string)")
-    @Test
-    void serializeVariableMap() throws Exception {
-        Map<String, Object> value = Map.of("id", "123", "name", "John");
-        Object result = invokeSerializeVariable(value, null);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof Map);
-        assertEquals("123", ((Map<?, ?>) result).get("id"));
-        assertEquals("John", ((Map<?, ?>) result).get("name"));
-    }
-
-    @DisplayName("serializeVariable: Complex nested Map structures")
-    @Test
-    void serializeVariableComplexNestedMap() throws Exception {
-        Map<String, Object> nested = Map.of("level", 2, "data", "nested");
-        Map<String, Object> value = Map.of(
-            "id", "123",
-            "nested", nested,
-            "list", List.of(1, 2, 3)
-        );
-        Object result = invokeSerializeVariable(value, null);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof Map);
-        Map<?, ?> resultMap = (Map<?, ?>) result;
-        assertEquals("123", resultMap.get("id"));
-        assertNotNull(resultMap.get("nested"));
-    }
-
-    @DisplayName("serializeVariable: List should be handled as Map (is JSON object)")
-    @Test
-    void serializeVariableList() throws Exception {
-        List<Object> value = List.of(1, 2, 3, "four");
-        Object result = invokeSerializeVariable(value, null);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof String || result instanceof List);
-    }
-
-    @DisplayName("serializeVariable: toString fallback for unknown types")
-    @Test
-    void serializeVariableToStringFallback() throws Exception {
-        Object value = new CustomObject("test-value");
-        Object result = invokeSerializeVariable(value, null);
-        
-        assertEquals("CustomObject(test-value)", result);
-    }
-
-    @DisplayName("serializeVariable: Empty Map should be preserved")
-    @Test
-    void serializeVariableEmptyMap() throws Exception {
-        Map<String, Object> value = new HashMap<>();
-        Object result = invokeSerializeVariable(value, null);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof Map);
-        assertTrue(((Map<?, ?>) result).isEmpty());
-    }
-
-    @DisplayName("serializeVariable: Map with null values should preserve nulls")
-    @Test
-    void serializeVariableMapWithNullValues() throws Exception {
-        Map<String, Object> value = new HashMap<>();
-        value.put("key1", "value1");
-        value.put("key2", null);
-        Object result = invokeSerializeVariable(value, null);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof Map);
-        Map<?, ?> resultMap = (Map<?, ?>) result;
-        assertEquals("value1", resultMap.get("key1"));
-        assertTrue(resultMap.containsKey("key2"));
-        assertNull(resultMap.get("key2"));
-    }
-
-    @DisplayName("serializeVariable: Double should be converted via toString fallback")
-    @Test
-    void serializeVariableDouble() throws Exception {
-        Double value = 3.14159;
-        Object result = invokeSerializeVariable(value, null);
-        assertEquals("3.14159", result);
-    }
-
-    @DisplayName("serializeVariable: Float should be converted via toString fallback")
-    @Test
-    void serializeVariableFloat() throws Exception {
-        Float value = 2.71f;
-        Object result = invokeSerializeVariable(value, null);
-        assertEquals("2.71", result.toString());
-    }
-
-    // ===================== Tests for convertToMap method =====================
-
-    @DisplayName("convertToMap: null input returns empty map")
-    @Test
-    void convertToMapNullInput() {
-        Map<String, Object> result = serializer.convertToMap(null);
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-    }
-
-    @DisplayName("convertToMap: HashMap input is converted")
-    @Test
-    void convertToMapHashMap() {
-        Map<String, Object> input = new HashMap<>();
-        input.put("key1", "value1");
-        input.put("key2", "value2");
-        
-        Map<String, Object> result = serializer.convertToMap(input);
-        assertNotNull(result);
-        assertTrue(result instanceof Map);
-        assertEquals("value1", result.get("key1"));
-        assertEquals("value2", result.get("key2"));
-    }
-
-    @DisplayName("convertToMap: Immutable Map is converted to new HashMap")
-    @Test
-    void convertToMapImmutableMap() {
-        Map<String, Object> input = Map.of("key", "value");
-        Map<String, Object> result = serializer.convertToMap(input);
-        
-        assertNotNull(result);
-        assertNotSame(input, result);
-        assertEquals("value", result.get("key"));
-    }
-
-    @DisplayName("convertToMap: Empty Map is preserved")
-    @Test
-    void convertToMapEmptyMap() {
-        Map<String, Object> input = new HashMap<>();
-        Map<String, Object> result = serializer.convertToMap(input);
-        
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-    }
-
-    // ===================== Tests for collectReturnVariables method =====================
-
-    @DisplayName("collectReturnVariables: no return variables configured")
-    @Test
-    void collectReturnVariablesEmpty() {
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(), false);
-        Map<String, Object> capturedVariables = Map.of("var1", "value1");
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-    }
-
-    @DisplayName("collectReturnVariables: single return variable")
-    @Test
-    void collectReturnVariablesSingle() {
-        ToolParameter returnVar = new ToolParameter("result", "string");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(returnVar), false);
-        Map<String, Object> capturedVariables = Map.of("result", "test-value");
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertEquals("test-value", result.get("result"));
-    }
-
-    @DisplayName("collectReturnVariables: multiple return variables")
-    @Test
-    void collectReturnVariablesMultiple() {
-        ToolParameter var1 = new ToolParameter("output1", "string");
-        ToolParameter var2 = new ToolParameter("output2", "integer");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2), false);
-        
-        Map<String, Object> capturedVariables = new HashMap<>();
-        capturedVariables.put("output1", "first");
-        capturedVariables.put("output2", 42);
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertEquals("first", result.get("output1"));
-        assertEquals(42, result.get("output2"));
-    }
-
-    @DisplayName("collectReturnVariables: missing variable is included as null")
-    @Test
-    void collectReturnVariablesMissingVariable() {
-        ToolParameter returnVar = new ToolParameter("missing", "string");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(returnVar), false);
-        Map<String, Object> capturedVariables = new HashMap<>();
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertTrue(result.containsKey("missing"));
-        assertNull(result.get("missing"));
-    }
-
-    @DisplayName("collectReturnVariables: mixed existing and missing variables")
-    @Test
-    void collectReturnVariablesMixed() {
-        ToolParameter var1 = new ToolParameter("exists", "string");
-        ToolParameter var2 = new ToolParameter("missing", "string");
-        ToolParameter var3 = new ToolParameter("alsoExists", "integer");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2, var3), false);
-        
-        Map<String, Object> capturedVariables = new HashMap<>();
-        capturedVariables.put("exists", "value1");
-        capturedVariables.put("alsoExists", 999);
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertEquals("value1", result.get("exists"));
-        assertNull(result.get("missing"));
-        assertEquals(999, result.get("alsoExists"));
-    }
-
-    @DisplayName("collectReturnVariables: preserves insertion order (LinkedHashMap)")
-    @Test
-    void collectReturnVariablesPreservesOrder() {
-        ToolParameter var1 = new ToolParameter("first", "string");
-        ToolParameter var2 = new ToolParameter("second", "string");
-        ToolParameter var3 = new ToolParameter("third", "string");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2, var3), false);
-        
-        Map<String, Object> capturedVariables = new HashMap<>();
-        capturedVariables.put("first", "1st");
-        capturedVariables.put("second", "2nd");
-        capturedVariables.put("third", "3rd");
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        
-        Object[] keys = result.keySet().toArray();
-        assertEquals("first", keys[0]);
-        assertEquals("second", keys[1]);
-        assertEquals("third", keys[2]);
-    }
-
-    @DisplayName("collectReturnVariables: handles complex serialized objects")
-    @Test
-    void collectReturnVariablesComplexObjects() {
-        Map<String, Object> complexObj = new HashMap<>();
-        complexObj.put("nested", Map.of("key", "value"));
-        complexObj.put("number", 42);
-        
-        ToolParameter var = new ToolParameter("complex", "object");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var), false);
-        
-        Map<String, Object> capturedVariables = Map.of("complex", complexObj);
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertNotNull(result.get("complex"));
-        assertTrue(result.get("complex") instanceof Map);
-    }
-
-    @DisplayName("collectReturnVariables: handles null values in captured variables")
-    @Test
-    void collectReturnVariablesWithNullCapturedValues() {
-        ToolParameter var1 = new ToolParameter("nullVar", "string");
-        ToolParameter var2 = new ToolParameter("realVar", "string");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2), false);
-        
-        Map<String, Object> capturedVariables = new HashMap<>();
-        capturedVariables.put("nullVar", null);
-        capturedVariables.put("realVar", "value");
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        assertTrue(result.containsKey("nullVar"));
-        assertNull(result.get("nullVar"));
-        assertEquals("value", result.get("realVar"));
-    }
-
-    @DisplayName("collectReturnVariables: large collection of return variables")
-    @Test
-    void collectReturnVariablesLargeCollection() {
-        List<ToolParameter> vars = new ArrayList<>();
-        Map<String, Object> capturedVars = new HashMap<>();
-        
-        for (int i = 0; i < 50; i++) {
-            String name = "var" + i;
-            vars.add(new ToolParameter(name, "string"));
-            capturedVars.put(name, "value" + i);
+        @Test
+        @DisplayName("null value returns null")
+        void nullValue() {
+            assertNull(serializer.normalize(null));
         }
-        
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), vars, false);
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVars);
-        assertNotNull(result);
-        assertEquals(50, result.size());
-        
-        assertEquals("value0", result.get("var0"));
-        assertEquals("value25", result.get("var25"));
-        assertEquals("value49", result.get("var49"));
+
+        @Test
+        @DisplayName("String is returned as-is")
+        void stringValue() {
+            assertEquals("test string", serializer.normalize("test string"));
+        }
+
+        @Test
+        @DisplayName("Integer is returned as-is")
+        void integerValue() {
+            assertEquals(42, serializer.normalize(42));
+        }
+
+        @Test
+        @DisplayName("Long is returned as-is")
+        void longValue() {
+            assertEquals(999L, serializer.normalize(999L));
+        }
+
+        @Test
+        @DisplayName("Boolean is returned as-is")
+        void booleanValue() {
+            assertEquals(true, serializer.normalize(true));
+            assertEquals(false, serializer.normalize(false));
+        }
+
+        @Test
+        @DisplayName("Date is returned as epoch millis")
+        void dateValue() {
+            Date date = new Date(1000000000000L);
+            assertEquals(1000000000000L, serializer.normalize(date));
+        }
+
+        @Test
+        @DisplayName("Map is returned as-is (JSON-compatible)")
+        void mapValue() {
+            Map<String, Object> value = Map.of("id", "123", "name", "John");
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            assertEquals("123", ((Map<?, ?>) result).get("id"));
+            assertEquals("John", ((Map<?, ?>) result).get("name"));
+        }
+
+        @Test
+        @DisplayName("Nested Map structures are preserved")
+        void nestedMapValue() {
+            Map<String, Object> nested = Map.of("level", 2, "data", "nested");
+            Map<String, Object> value = Map.of(
+                "id", "123",
+                "nested", nested,
+                "list", List.of(1, 2, 3)
+            );
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> resultMap = (Map<?, ?>) result;
+            assertEquals("123", resultMap.get("id"));
+            assertNotNull(resultMap.get("nested"));
+        }
+
+        @Test
+        @DisplayName("Empty Map is preserved")
+        void emptyMapValue() {
+            Map<String, Object> value = new HashMap<>();
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            assertTrue(((Map<?, ?>) result).isEmpty());
+        }
+
+        @Test
+        @DisplayName("Map with null values preserves nulls")
+        void mapWithNullValues() {
+            Map<String, Object> value = new HashMap<>();
+            value.put("key1", "value1");
+            value.put("key2", null);
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> resultMap = (Map<?, ?>) result;
+            assertEquals("value1", resultMap.get("key1"));
+            assertTrue(resultMap.containsKey("key2"));
+            assertNull(resultMap.get("key2"));
+        }
+
+        @Test
+        @DisplayName("Double is serialized via Jackson round-trip")
+        void doubleValue() {
+            Object result = serializer.normalize(3.14159);
+            assertEquals(3.14159, result);
+        }
+
+        @Test
+        @DisplayName("Float is serialized via Jackson round-trip")
+        void floatValue() {
+            Object result = serializer.normalize(2.71f);
+            // Jackson converts Float to Double
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("List is serialized via Jackson round-trip")
+        void listValue() {
+            List<Object> value = List.of(1, 2, 3, "four");
+            Object result = serializer.normalize(value);
+
+            assertNotNull(result);
+            assertInstanceOf(List.class, result);
+            List<?> list = (List<?>) result;
+            assertEquals(4, list.size());
+            assertEquals("four", list.get(3));
+        }
+
+        @Test
+        @DisplayName("Custom object falls back to toString")
+        void customObjectFallback() {
+            Object value = new CustomObject("test-value");
+            Object result = serializer.normalize(value);
+
+            assertEquals("CustomObject(test-value)", result);
+        }
+
+        @Test
+        @DisplayName("Serializable POJO is converted via Jackson")
+        void serializablePojo() {
+            SerializablePojo pojo = new SerializablePojo("hello", 42);
+            Object result = serializer.normalize(pojo);
+
+            assertNotNull(result);
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> map = (Map<?, ?>) result;
+            assertEquals("hello", map.get("name"));
+            assertEquals(42, map.get("count"));
+        }
     }
 
-    @DisplayName("collectReturnVariables: case-sensitive variable matching")
-    @Test
-    void collectReturnVariablesCaseSensitive() {
-        ToolParameter var1 = new ToolParameter("MyVar", "string");
-        ToolParameter var2 = new ToolParameter("myvar", "string");
-        ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2), false);
-        
-        Map<String, Object> capturedVariables = new HashMap<>();
-        capturedVariables.put("MyVar", "uppercase");
-        capturedVariables.put("myvar", "lowercase");
-        
-        Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVariables);
-        assertNotNull(result);
-        
-        assertEquals("uppercase", result.get("MyVar"));
-        assertEquals("lowercase", result.get("myvar"));
-        assertEquals(2, result.size());
+    // ===================== Tests for convertToMap =====================
+
+    @Nested
+    @DisplayName("convertToMap")
+    class ConvertToMapTests {
+
+        @Test
+        @DisplayName("null input returns empty map")
+        void nullInput() {
+            Map<String, Object> result = serializer.convertToMap(null);
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("HashMap input is converted")
+        void hashMapInput() {
+            Map<String, Object> input = new HashMap<>();
+            input.put("key1", "value1");
+            input.put("key2", "value2");
+
+            Map<String, Object> result = serializer.convertToMap(input);
+            assertNotNull(result);
+            assertEquals("value1", result.get("key1"));
+            assertEquals("value2", result.get("key2"));
+        }
+
+        @Test
+        @DisplayName("Immutable Map is converted to new mutable HashMap")
+        void immutableMapInput() {
+            Map<String, Object> input = Map.of("key", "value");
+            Map<String, Object> result = serializer.convertToMap(input);
+
+            assertNotNull(result);
+            assertNotSame(input, result);
+            assertEquals("value", result.get("key"));
+        }
+
+        @Test
+        @DisplayName("Empty Map is preserved")
+        void emptyMapInput() {
+            Map<String, Object> input = new HashMap<>();
+            Map<String, Object> result = serializer.convertToMap(input);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    // ===================== Tests for JSON parsing methods =====================
+    // ===================== Tests for collectReturnVariables =====================
 
-    @DisplayName("parseJsonString: null input returns null")
-    @Test
-    void parseJsonStringNull() {
-        Object result = serializer.parseJsonString(null);
-        assertNull(result);
+    @Nested
+    @DisplayName("collectReturnVariables")
+    class CollectReturnVariablesTests {
+
+        @Test
+        @DisplayName("no return variables configured yields empty map")
+        void noReturnVariables() {
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(), false);
+            Map<String, Object> captured = Map.of("var1", "value1");
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("single return variable")
+        void singleReturnVariable() {
+            ToolParameter returnVar = new ToolParameter("result", "string");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(returnVar), false);
+            Map<String, Object> captured = Map.of("result", "test-value");
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertEquals("test-value", result.get("result"));
+        }
+
+        @Test
+        @DisplayName("multiple return variables")
+        void multipleReturnVariables() {
+            ToolParameter var1 = new ToolParameter("output1", "string");
+            ToolParameter var2 = new ToolParameter("output2", "integer");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2), false);
+
+            Map<String, Object> captured = new HashMap<>();
+            captured.put("output1", "first");
+            captured.put("output2", 42);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertEquals("first", result.get("output1"));
+            assertEquals(42, result.get("output2"));
+        }
+
+        @Test
+        @DisplayName("missing variable is included as null")
+        void missingVariable() {
+            ToolParameter returnVar = new ToolParameter("missing", "string");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(returnVar), false);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, new HashMap<>());
+            assertTrue(result.containsKey("missing"));
+            assertNull(result.get("missing"));
+        }
+
+        @Test
+        @DisplayName("mixed existing and missing variables")
+        void mixedVariables() {
+            ToolParameter var1 = new ToolParameter("exists", "string");
+            ToolParameter var2 = new ToolParameter("missing", "string");
+            ToolParameter var3 = new ToolParameter("alsoExists", "integer");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2, var3), false);
+
+            Map<String, Object> captured = new HashMap<>();
+            captured.put("exists", "value1");
+            captured.put("alsoExists", 999);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertEquals("value1", result.get("exists"));
+            assertNull(result.get("missing"));
+            assertEquals(999, result.get("alsoExists"));
+        }
+
+        @Test
+        @DisplayName("preserves insertion order (LinkedHashMap)")
+        void preservesOrder() {
+            ToolParameter var1 = new ToolParameter("first", "string");
+            ToolParameter var2 = new ToolParameter("second", "string");
+            ToolParameter var3 = new ToolParameter("third", "string");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2, var3), false);
+
+            Map<String, Object> captured = new HashMap<>();
+            captured.put("first", "1st");
+            captured.put("second", "2nd");
+            captured.put("third", "3rd");
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            Object[] keys = result.keySet().toArray();
+            assertEquals("first", keys[0]);
+            assertEquals("second", keys[1]);
+            assertEquals("third", keys[2]);
+        }
+
+        @Test
+        @DisplayName("handles complex nested objects")
+        void complexObjects() {
+            Map<String, Object> complexObj = new HashMap<>();
+            complexObj.put("nested", Map.of("key", "value"));
+            complexObj.put("number", 42);
+
+            ToolParameter var = new ToolParameter("complex", "object");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var), false);
+
+            Map<String, Object> captured = Map.of("complex", complexObj);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertNotNull(result.get("complex"));
+            assertInstanceOf(Map.class, result.get("complex"));
+        }
+
+        @Test
+        @DisplayName("handles null values in captured variables")
+        void nullCapturedValues() {
+            ToolParameter var1 = new ToolParameter("nullVar", "string");
+            ToolParameter var2 = new ToolParameter("realVar", "string");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2), false);
+
+            Map<String, Object> captured = new HashMap<>();
+            captured.put("nullVar", null);
+            captured.put("realVar", "value");
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertTrue(result.containsKey("nullVar"));
+            assertNull(result.get("nullVar"));
+            assertEquals("value", result.get("realVar"));
+        }
+
+        @Test
+        @DisplayName("large collection of return variables")
+        void largeCollection() {
+            List<ToolParameter> vars = new ArrayList<>();
+            Map<String, Object> capturedVars = new HashMap<>();
+
+            for (int i = 0; i < 50; i++) {
+                String name = "var" + i;
+                vars.add(new ToolParameter(name, "string"));
+                capturedVars.put(name, "value" + i);
+            }
+
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), vars, false);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, capturedVars);
+            assertEquals(50, result.size());
+            assertEquals("value0", result.get("var0"));
+            assertEquals("value25", result.get("var25"));
+            assertEquals("value49", result.get("var49"));
+        }
+
+        @Test
+        @DisplayName("case-sensitive variable matching")
+        void caseSensitive() {
+            ToolParameter var1 = new ToolParameter("MyVar", "string");
+            ToolParameter var2 = new ToolParameter("myvar", "string");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var1, var2), false);
+
+            Map<String, Object> captured = new HashMap<>();
+            captured.put("MyVar", "uppercase");
+            captured.put("myvar", "lowercase");
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertEquals("uppercase", result.get("MyVar"));
+            assertEquals("lowercase", result.get("myvar"));
+        }
+
+        @Test
+        @DisplayName("POJO return variable is serialized to Map via Jackson")
+        void pojoReturnVariable() {
+            SerializablePojo pojo = new SerializablePojo("order-data", 7);
+
+            ToolParameter var = new ToolParameter("output", "object");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var), false);
+
+            Map<String, Object> captured = Map.of("output", pojo);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertNotNull(result.get("output"));
+            assertInstanceOf(Map.class, result.get("output"));
+            Map<?, ?> outputMap = (Map<?, ?>) result.get("output");
+            assertEquals("order-data", outputMap.get("name"));
+            assertEquals(7, outputMap.get("count"));
+        }
+
+        @Test
+        @DisplayName("Custom object without getters falls back to toString")
+        void customObjectReturnVariable() {
+            CustomObject custom = new CustomObject("workflow-result");
+
+            ToolParameter var = new ToolParameter("result", "object");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc", List.of(), List.of(var), false);
+
+            Map<String, Object> captured = Map.of("result", custom);
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+            assertEquals("CustomObject(workflow-result)", result.get("result"));
+        }
+
+        @Test
+        @DisplayName("Mixed types: primitives, POJO, List, and custom object together")
+        void mixedTypeReturnVariables() {
+            SerializablePojo pojo = new SerializablePojo("item", 3);
+            CustomObject custom = new CustomObject("fallback");
+
+            ToolParameter var1 = new ToolParameter("name", "string");
+            ToolParameter var2 = new ToolParameter("count", "integer");
+            ToolParameter var3 = new ToolParameter("active", "boolean");
+            ToolParameter var4 = new ToolParameter("pojo", "object");
+            ToolParameter var5 = new ToolParameter("custom", "object");
+            ToolParameter var6 = new ToolParameter("tags", "object");
+            ToolDefinition definition = new ToolDefinition("process", "tool", "desc",
+                    List.of(), List.of(var1, var2, var3, var4, var5, var6), false);
+
+            Map<String, Object> captured = new HashMap<>();
+            captured.put("name", "test");
+            captured.put("count", 42);
+            captured.put("active", true);
+            captured.put("pojo", pojo);
+            captured.put("custom", custom);
+            captured.put("tags", List.of("alpha", "beta"));
+
+            Map<String, Object> result = serializer.collectReturnVariables(definition, captured);
+
+            assertEquals("test", result.get("name"));
+            assertEquals(42, result.get("count"));
+            assertEquals(true, result.get("active"));
+
+            assertInstanceOf(Map.class, result.get("pojo"));
+            Map<?, ?> pojoMap = (Map<?, ?>) result.get("pojo");
+            assertEquals("item", pojoMap.get("name"));
+            assertEquals(3, pojoMap.get("count"));
+
+            assertEquals("CustomObject(fallback)", result.get("custom"));
+
+            assertInstanceOf(List.class, result.get("tags"));
+            List<?> tags = (List<?>) result.get("tags");
+            assertEquals(2, tags.size());
+            assertEquals("alpha", tags.get(0));
+        }
     }
 
-    @DisplayName("parseJsonString: empty string returns empty string")
-    @Test
-    void parseJsonStringEmpty() {
-        Object result = serializer.parseJsonString("");
-        assertEquals("", result);
+    // ===================== Tests for parseJsonString =====================
+
+    @Nested
+    @DisplayName("parseJsonString")
+    class ParseJsonStringTests {
+
+        @Test
+        @DisplayName("null input returns null")
+        void nullInput() {
+            assertNull(serializer.parseJsonString(null));
+        }
+
+        @Test
+        @DisplayName("empty string returns empty string")
+        void emptyInput() {
+            assertEquals("", serializer.parseJsonString(""));
+        }
+
+        @Test
+        @DisplayName("non-JSON string returns as-is")
+        void nonJsonInput() {
+            assertEquals("not json", serializer.parseJsonString("not json"));
+        }
+
+        @Test
+        @DisplayName("JSON object is parsed to Map")
+        void jsonObject() {
+            String json = "{\"id\":\"123\",\"name\":\"John\"}";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> map = (Map<?, ?>) result;
+            assertEquals("123", map.get("id"));
+            assertEquals("John", map.get("name"));
+        }
+
+        @Test
+        @DisplayName("nested JSON object")
+        void nestedJsonObject() {
+            String json = "{\"user\":{\"id\":\"123\",\"profile\":{\"name\":\"John\"}}}";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> map = (Map<?, ?>) result;
+            assertInstanceOf(Map.class, map.get("user"));
+            Map<?, ?> userMap = (Map<?, ?>) map.get("user");
+            assertInstanceOf(Map.class, userMap.get("profile"));
+        }
+
+        @Test
+        @DisplayName("JSON array is parsed to List")
+        void jsonArray() {
+            String json = "[1,2,3]";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(List.class, result);
+            List<?> list = (List<?>) result;
+            assertEquals(3, list.size());
+        }
+
+        @Test
+        @DisplayName("empty JSON object returns empty Map")
+        void emptyJsonObject() {
+            Object result = serializer.parseJsonString("{}");
+            assertInstanceOf(Map.class, result);
+            assertTrue(((Map<?, ?>) result).isEmpty());
+        }
+
+        @Test
+        @DisplayName("empty JSON array returns empty List")
+        void emptyJsonArray() {
+            Object result = serializer.parseJsonString("[]");
+            assertInstanceOf(List.class, result);
+            assertTrue(((List<?>) result).isEmpty());
+        }
+
+        @Test
+        @DisplayName("escaped backslash in string value")
+        void escapedBackslash() {
+            String json = "{\"path\":\"C:\\\\\"}";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> map = (Map<?, ?>) result;
+            assertEquals("C:\\", map.get("path"));
+        }
+
+        @Test
+        @DisplayName("mixed escape sequences")
+        void mixedEscapes() {
+            String json = "{\"file\":\"C:\\\\Users\\\\test\\\\\",\"message\":\"Line1\\nLine2\",\"quoted\":\"He said \\\"Hi\\\"\"}";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> map = (Map<?, ?>) result;
+            assertEquals(3, map.size());
+
+            String file = (String) map.get("file");
+            String message = (String) map.get("message");
+            String quoted = (String) map.get("quoted");
+
+            assertTrue(file.contains("Users"));
+            assertTrue(message.contains("Line1") && message.contains("Line2"));
+            assertTrue(quoted.contains("Hi"));
+        }
+
+        @Test
+        @DisplayName("JSON with various value types")
+        void variousTypes() {
+            String json = "{\"str\":\"hello\",\"num\":42,\"bool\":true,\"nil\":null,\"arr\":[1,2]}";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> map = (Map<?, ?>) result;
+            assertEquals("hello", map.get("str"));
+            assertEquals(42, map.get("num"));
+            assertEquals(true, map.get("bool"));
+            assertNull(map.get("nil"));
+            assertInstanceOf(List.class, map.get("arr"));
+        }
+
+        @Test
+        @DisplayName("deeply nested JSON")
+        void deeplyNested() {
+            String json = "{\"a\":{\"b\":{\"c\":{\"d\":\"deep\"}}}}";
+            Object result = serializer.parseJsonString(json);
+
+            assertInstanceOf(Map.class, result);
+            Map<?, ?> a = (Map<?, ?>) ((Map<?, ?>) result).get("a");
+            Map<?, ?> b = (Map<?, ?>) a.get("b");
+            Map<?, ?> c = (Map<?, ?>) b.get("c");
+            assertEquals("deep", c.get("d"));
+        }
+
+        @Test
+        @DisplayName("invalid JSON returns string as-is")
+        void invalidJson() {
+            String json = "{invalid json}";
+            Object result = serializer.parseJsonString(json);
+            assertEquals(json, result);
+        }
     }
 
-    @DisplayName("parseJsonString: non-JSON string returns as-is")
-    @Test
-    void parseJsonStringNonJson() {
-        Object result = serializer.parseJsonString("not json");
-        assertEquals("not json", result);
-    }
-
-    @DisplayName("parseJsonString: JSON object is parsed to Map")
-    @Test
-    void parseJsonStringObject() {
-        String json = "{\"id\":\"123\",\"name\":\"John\"}";
-        Object result = serializer.parseJsonString(json);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof Map);
-        Map<?, ?> map = (Map<?, ?>) result;
-        assertEquals("123", map.get("id"));
-        assertEquals("John", map.get("name"));
-    }
-
-    @DisplayName("parseJsonString: nested JSON object is parsed correctly")
-    @Test
-    void parseJsonStringNestedObject() {
-        String json = "{\"user\":{\"id\":\"123\",\"profile\":{\"name\":\"John\"}}}";
-        Object result = serializer.parseJsonString(json);
-        
-        assertTrue(result instanceof Map);
-        Map<?, ?> map = (Map<?, ?>) result;
-        assertTrue(map.get("user") instanceof Map);
-        Map<?, ?> userMap = (Map<?, ?>) map.get("user");
-        assertTrue(userMap.get("profile") instanceof Map);
-    }
-
-    @DisplayName("parseJsonString: JSON array is parsed to List")
-    @Test
-    void parseJsonStringArray() {
-        String json = "[1,2,3]";
-        Object result = serializer.parseJsonString(json);
-        
-        assertNotNull(result);
-        assertTrue(result instanceof List);
-        List<?> list = (List<?>) result;
-        assertTrue(list.size() > 0);
-    }
-
-    @DisplayName("parseJsonString: empty JSON object returns empty Map")
-    @Test
-    void parseJsonStringEmptyObject() {
-        String json = "{}";
-        Object result = serializer.parseJsonString(json);
-        
-        assertTrue(result instanceof Map);
-        assertTrue(((Map<?, ?>) result).isEmpty());
-    }
-
-    @DisplayName("parseJsonString: empty JSON array returns empty List")
-    @Test
-    void parseJsonStringEmptyArray() {
-        String json = "[]";
-        Object result = serializer.parseJsonString(json);
-        
-        assertTrue(result instanceof List);
-        assertTrue(((List<?>) result).isEmpty());
-    }
-
-    @DisplayName("parseJsonString: correctly parses string ending with escaped backslash")
-    @Test
-    void parseJsonStringBackslashAtStringEnd() {
-        // JSON: {"path":"C:\\"} - the string ends with a single backslash, quote closes the string
-        String json = "{\"path\":\"C:\\\\\"}";
-        
-        Object result = serializer.parseJsonString(json);
-        
-        assertTrue(result instanceof Map);
-        Map<?, ?> map = (Map<?, ?>) result;
-        assertTrue(map.containsKey("path"));
-        String path = (String) map.get("path");
-        assertEquals("C:\\", path);
-    }
-
-    @DisplayName("parseJsonString: correctly handles mixed escape sequences")
-    @Test
-    void parseJsonStringMixedEscapeSequences() {
-        // Complex JSON with: path with backslashes, escaped quotes, newlines
-        String json = "{\"file\":\"C:\\\\Users\\\\test\\\\\",\"message\":\"Line1\\nLine2\",\"quoted\":\"He said \\\"Hi\\\"\"}";
-        
-        Object result = serializer.parseJsonString(json);
-        
-        assertTrue(result instanceof Map);
-        Map<?, ?> map = (Map<?, ?>) result;
-        assertEquals(3, map.size());
-        
-        String file = (String) map.get("file");
-        String message = (String) map.get("message");
-        String quoted = (String) map.get("quoted");
-        
-        assertTrue(file.contains("Users"));
-        assertTrue(message.contains("Line1") && message.contains("Line2"));
-        assertTrue(quoted.contains("Hi"));
-    }
-
-    // ===================== Helper methods =====================
-
-    private Object invokeSerializeVariable(Object value, String typeHint) throws Exception {
-        Method method = VariableSerializer.class.getDeclaredMethod("serializeVariable", Object.class, String.class);
-        method.setAccessible(true);
-        return method.invoke(serializer, value, typeHint);
-    }
-
-    private boolean invokeIsNotInString(String str, int pos) throws Exception {
-        Method method = VariableSerializer.class.getDeclaredMethod("isNotInString", String.class, int.class);
-        method.setAccessible(true);
-        return (boolean) method.invoke(serializer, str, pos);
-    }
+    // ===================== Helper classes =====================
 
     static class CustomObject {
         private final String value;
@@ -526,5 +620,21 @@ class VariableSerializerTest {
         public String toString() {
             return "CustomObject(" + value + ")";
         }
+    }
+
+    /**
+     * A simple POJO that Jackson can serialize (has public getters).
+     */
+    static class SerializablePojo {
+        private final String name;
+        private final int count;
+
+        SerializablePojo(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String getName() { return name; }
+        public int getCount() { return count; }
     }
 }

--- a/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolRegistry.java
+++ b/agentic/mcp-server-plugin/src/main/java/org/finos/fluxnova/ai/mcp/server/registry/ToolRegistry.java
@@ -2,6 +2,8 @@ package org.finos.fluxnova.ai.mcp.server.registry;
 
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -147,25 +149,20 @@ public class ToolRegistry {
     /**
      * Builds an MCP Tool from a ToolConfig.
      * Uses the raw JSON schema if provided, otherwise builds one from parameter specs.
+     *
+     * <p>Uses the builder API for compatibility with MCP SDK 2.0.0 where
+     * Tool.inputSchema is Map&lt;String, Object> but the builder accepts JsonSchema.</p>
      */
     private Tool buildTool(ToolConfig config) {
         JsonSchema schema = config.rawSchema() != null
                 ? config.rawSchema()
                 : buildJsonSchema(config.parameters());
 
-        // Convert JsonSchema to Map for the Tool constructor
-        @SuppressWarnings("unchecked")
-        Map<String, Object> schemaMap = objectMapper.convertValue(schema, Map.class);
-
-        return new Tool(
-                config.name(),
-                null,  // href - not used
-                config.description(),
-                schemaMap,
-                null,  // annotations - not used
-                null,  // _meta - not used
-                null   // additionalProperties - not used
-        );
+        return Tool.builder()
+                .name(config.name())
+                .description(config.description())
+                .inputSchema(schema)
+                .build();
     }
 
     /**
@@ -190,7 +187,7 @@ public class ToolRegistry {
         parameters.forEach((name, spec) -> {
             Map<String, Object> property = new HashMap<>();
             String type = spec.type();
-            
+
             // Convert BPMN semantic types to valid JSON Schema types
             switch (type) {
                 case "Date":
@@ -218,7 +215,7 @@ public class ToolRegistry {
                     // String, Text, or any other type defaults to string
                     property.put("type", "string");
             }
-            
+
             property.put("description", "Parameter: " + name);
             properties.put(name, property);
 
@@ -239,11 +236,14 @@ public class ToolRegistry {
 
     /**
      * Builds a tool specification with the execution handler.
+     *
+     * <p>Uses the builder API for compatibility with MCP SDK 2.0.0 where
+     * SyncToolSpecification is now a 2-arg record (tool, callHandler).</p>
      */
     private SyncToolSpecification buildToolSpecification(Tool tool, ToolConfig config) {
-        return new SyncToolSpecification(
-                tool,
-                (exchange, callToolRequest) -> {
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((McpSyncServerExchange exchange, CallToolRequest callToolRequest) -> {
                     try {
                         LOG.debug("MCP - Executing tool '{}' with request: {}", config.name(), callToolRequest);
 
@@ -251,7 +251,7 @@ public class ToolRegistry {
                                 ? callToolRequest.arguments()
                                 : Map.of();
                         Object result = config.handler().execute(args);
-
+                        
                         String resultText = formatResult(result);
 
                         LOG.debug("MCP - Tool '{}' executed successfully", config.name());
@@ -271,8 +271,8 @@ public class ToolRegistry {
                                 null     // additionalProperties
                         );
                     }
-                }
-        );
+                })
+                .build();
     }
 
     /**


### PR DESCRIPTION
Allows BPMN process designers to configure a set of process variables that should be returned to the MCP client when a process is started. Currently, the MCP tool only returns process instance metadata.