### PR TITLE
Add LLM token usage, prompt-cache options, and per-instance agent con…

### DIFF
--- a/agentic-subprocess/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigExtractor.java
+++ b/agentic-subprocess/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/extract/AgentConfigExtractor.java
@@ -60,13 +60,28 @@ public class AgentConfigExtractor {
         String provider = config.attribute("provider");
         String model = config.attribute("model");
         String systemPrompt = config.attribute("systemPrompt");
+        String cacheStrategy = config.attribute("cacheStrategy");
+        String promptCacheKey = config.attribute("promptCacheKey");
 
         String toolScopeElementId = config.attribute("toolScopeElementId");
         if (isBlankOrNull(toolScopeElementId)) {
             toolScopeElementId = elementId;
         }
 
-        return Optional.of(new AgentConfig(processDefinitionId, elementId, provider, model, systemPrompt, toolScopeElementId));
+        return Optional.of(
+                new AgentConfig(
+                        processDefinitionId,
+                        elementId,
+                        provider,
+                        model,
+                        systemPrompt,
+                        toolScopeElementId,
+                        blankToNull(cacheStrategy),
+                        blankToNull(promptCacheKey)));
+    }
+
+    private static String blankToNull(String value) {
+        return isBlankOrNull(value) ? null : value;
     }
 
     private static boolean isBlankOrNull(String value) {

--- a/agentic-subprocess/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/model/AgentConfig.java
+++ b/agentic-subprocess/agent-config/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/model/AgentConfig.java
@@ -5,11 +5,20 @@ package org.finos.fluxnova.bpm.engine.ai.agent.model;
  *
  * @param processDefinitionId process definition that owns the configured element
  * @param elementId           BPMN element id carrying the agent configuration
- * @param provider            AI provider identifier (e.g. {@code "ollama"}, {@code "huggingface"})
- * @param model               model identifier within the provider (e.g. {@code "llama3"}, {@code "mistral"})
- * @param systemPrompt        system prompt text supplied to the agent, may be {@code null}
+ * @param provider            AI provider identifier (e.g. {@code "openai"}, {@code "anthropic"}),
+ *                            or a process-engine expression such as {@code "${llmProvider}"}
+ *                            evaluated per instance at orchestration time
+ * @param model               model identifier within the provider (e.g. {@code "gpt-5.4"}),
+ *                            or a process-engine expression such as {@code "${llmModel}"}
+ * @param systemPrompt        system prompt text supplied to the agent, may be {@code null};
+ *                            may contain expressions (including composite text)
  * @param toolScopeElementId  BPMN element id that defines the tool-resolution scope; when omitted
  *                            in BPMN, this defaults to {@code elementId}
+ * @param cacheStrategy       optional Anthropic prompt-cache strategy (e.g. {@code SYSTEM_AND_TOOLS}),
+ *                            or an expression such as {@code "${cacheStrategy}"}; ignored for
+ *                            non-Anthropic providers
+ * @param promptCacheKey      optional OpenAI {@code prompt_cache_key}, or an expression such as
+ *                            {@code "${promptCacheKey}"}; ignored for non-OpenAI providers
  */
 public record AgentConfig(
     String processDefinitionId,
@@ -17,5 +26,27 @@ public record AgentConfig(
     String provider,
     String model,
     String systemPrompt,
-    String toolScopeElementId
-) {}
+    String toolScopeElementId,
+    String cacheStrategy,
+    String promptCacheKey
+) {
+
+    /** Convenience constructor for configs without cache settings. */
+    public AgentConfig(
+            String processDefinitionId,
+            String elementId,
+            String provider,
+            String model,
+            String systemPrompt,
+            String toolScopeElementId) {
+        this(
+                processDefinitionId,
+                elementId,
+                provider,
+                model,
+                systemPrompt,
+                toolScopeElementId,
+                null,
+                null);
+    }
+}

--- a/agentic-subprocess/agent-llm-connector/pom.xml
+++ b/agentic-subprocess/agent-llm-connector/pom.xml
@@ -48,6 +48,17 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-client-chat</artifactId>
         </dependency>
+        <!-- Optional at runtime: only needed when the corresponding provider is selected. -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-anthropic</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/parser/AgentProviderParseListener.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/parser/AgentProviderParseListener.java
@@ -13,6 +13,13 @@ import java.util.StringJoiner;
 
 import static org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants.AGENT_NS;
 
+/**
+ * Validates that literal {@code agent:config provider} values resolve to a registered
+ * {@link AgentProviderRegistry} entry at deploy time.
+ *
+ * <p>Providers that contain process-engine expressions (e.g. {@code ${creditRiskAgentProvider}})
+ * are skipped here — they are evaluated per instance before the LLM call.
+ */
 public class AgentProviderParseListener extends AbstractBpmnParseListener {
 
     private final AgentProviderRegistry registry;
@@ -43,7 +50,7 @@ public class AgentProviderParseListener extends AbstractBpmnParseListener {
                     continue;
                 }
                 String provider = config.attribute("provider");
-                if (provider == null || provider.isBlank()) {
+                if (provider == null || provider.isBlank() || isExpression(provider)) {
                     continue;
                 }
                 if (!registry.has(provider)) {
@@ -63,5 +70,13 @@ public class AgentProviderParseListener extends AbstractBpmnParseListener {
                     "Invalid provider reference(s) in agent:config: " + joiner,
                     firstOffending);
         }
+    }
+
+    /**
+     * True when {@code provider} is (or contains) a process-engine expression that must be
+     * resolved at orchestration time rather than validated against the registry at deploy.
+     */
+    static boolean isExpression(String provider) {
+        return provider.contains("${") || provider.contains("#{");
     }
 }

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/AnthropicChatOptionsFactory.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/AnthropicChatOptionsFactory.java
@@ -1,0 +1,53 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.llm.service;
+
+import org.springframework.ai.anthropic.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+import java.util.Locale;
+
+/**
+ * Builds Anthropic-specific chat options including prompt cache strategy.
+ *
+ * <p>This class imports {@code spring-ai-anthropic} types directly. It is only instantiated
+ * when {@code spring-ai-anthropic} is confirmed present on the classpath (checked by
+ * {@link SpringAiLlmService} before creating an instance). If the JAR is absent, this class
+ * is never loaded by the JVM.</p>
+ */
+final class AnthropicChatOptionsFactory implements ProviderChatOptionsFactory {
+
+    @Override
+    public ChatOptions.Builder<?> build(String model, String cacheStrategy, String promptCacheKey) {
+        if (model == null && cacheStrategy == null) {
+            return null;
+        }
+        AnthropicChatOptions.Builder builder = AnthropicChatOptions.builder();
+        if (model != null) {
+            builder.model(model);
+        }
+        if (cacheStrategy != null) {
+            AnthropicCacheStrategy strategy = parseCacheStrategy(cacheStrategy);
+            AnthropicCacheOptions.Builder cacheOptions =
+                    AnthropicCacheOptions.builder().strategy(strategy);
+            if (strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY) {
+                cacheOptions.cacheToolResults(true);
+            }
+            builder.cacheOptions(cacheOptions.build());
+        }
+        return builder;
+    }
+
+    private static AnthropicCacheStrategy parseCacheStrategy(String raw) {
+        try {
+            return AnthropicCacheStrategy.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException(
+                    "Unknown Anthropic cacheStrategy '"
+                            + raw
+                            + "'. Expected one of: NONE, TOOLS_ONLY, SYSTEM_ONLY, "
+                            + "SYSTEM_AND_TOOLS, CONVERSATION_HISTORY",
+                    ex);
+        }
+    }
+}

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/ConversationMapper.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/ConversationMapper.java
@@ -4,8 +4,10 @@ import org.finos.fluxnova.bpm.engine.ai.agent.discovery.model.ResolvedContext;
 import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
 import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
 import org.finos.fluxnova.bpm.engine.shared.model.LlmResponse;
+import org.finos.fluxnova.bpm.engine.shared.model.TokenUsage;
 import org.finos.fluxnova.bpm.engine.shared.model.ToolCallRequest;
 import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 
 import java.util.ArrayList;
@@ -100,7 +102,37 @@ class ConversationMapper {
                 priorHistory == null ? List.of() : priorHistory);
         updated.add(ConversationEntry.assistant(text, toolCalls));
 
-        return new LlmResponse(text, toolCalls, updated);
+        return new LlmResponse(text, toolCalls, updated, extractTokenUsage(response));
+    }
+
+    private static TokenUsage extractTokenUsage(ChatResponse response) {
+        if (response == null || response.getMetadata() == null) {
+            return null;
+        }
+        Usage usage = response.getMetadata().getUsage();
+        if (usage == null) {
+            return null;
+        }
+        Integer prompt = usage.getPromptTokens();
+        Integer completion = usage.getCompletionTokens();
+        Integer total = usage.getTotalTokens();
+        if (prompt == null && completion == null && total == null) {
+            return null;
+        }
+        int promptTokens = prompt != null ? prompt : 0;
+        int completionTokens = completion != null ? completion : 0;
+        int totalTokens = total != null ? total : promptTokens + completionTokens;
+        int cacheRead = toInt(usage.getCacheReadInputTokens());
+        int cacheWrite = toInt(usage.getCacheWriteInputTokens());
+        return new TokenUsage(
+                promptTokens, completionTokens, totalTokens, cacheRead, cacheWrite);
+    }
+
+    private static int toInt(Long value) {
+        if (value == null || value <= 0L) {
+            return 0;
+        }
+        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : value.intValue();
     }
 
     private static String formatContext(ResolvedContext context) {

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/OpenAiChatOptionsFactory.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/OpenAiChatOptionsFactory.java
@@ -1,0 +1,30 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.llm.service;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+/**
+ * Builds OpenAI-specific chat options including prompt cache key.
+ *
+ * <p>This class imports {@code spring-ai-openai} types directly. It is only instantiated
+ * when {@code spring-ai-openai} is confirmed present on the classpath (checked by
+ * {@link SpringAiLlmService} before creating an instance). If the JAR is absent, this class
+ * is never loaded by the JVM.</p>
+ */
+final class OpenAiChatOptionsFactory implements ProviderChatOptionsFactory {
+
+    @Override
+    public ChatOptions.Builder<?> build(String model, String cacheStrategy, String promptCacheKey) {
+        if (model == null && promptCacheKey == null) {
+            return null;
+        }
+        OpenAiChatOptions.Builder builder = OpenAiChatOptions.builder();
+        if (model != null) {
+            builder.model(model);
+        }
+        if (promptCacheKey != null) {
+            builder.promptCacheKey(promptCacheKey);
+        }
+        return builder;
+    }
+}

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/ProviderChatOptionsFactory.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/ProviderChatOptionsFactory.java
@@ -1,0 +1,24 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.llm.service;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+/**
+ * Strategy interface for building provider-specific {@link ChatOptions} at request time.
+ *
+ * <p>Implementations live in separate classes that import provider-specific Spring AI types.
+ * The JVM only loads an implementation when it's actually instantiated, so missing provider
+ * JARs (e.g. {@code spring-ai-anthropic}) won't cause {@link NoClassDefFoundError} at
+ * startup.</p>
+ */
+interface ProviderChatOptionsFactory {
+
+    /**
+     * Builds provider-specific chat options based on the resolved agent configuration values.
+     *
+     * @param model          the model identifier (may be {@code null})
+     * @param cacheStrategy  the Anthropic cache strategy name (may be {@code null})
+     * @param promptCacheKey the OpenAI prompt cache key (may be {@code null})
+     * @return a configured {@link ChatOptions.Builder}, or {@code null} if no options needed
+     */
+    ChatOptions.Builder<?> build(String model, String cacheStrategy, String promptCacheKey);
+}

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/SpringAiLlmService.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/SpringAiLlmService.java
@@ -8,9 +8,6 @@ import org.finos.fluxnova.bpm.engine.ai.agent.llm.tool.AgentToolSchemaConverter;
 import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
 import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
 import org.finos.fluxnova.bpm.engine.shared.model.LlmResponse;
-import org.springframework.ai.anthropic.AnthropicCacheOptions;
-import org.springframework.ai.anthropic.AnthropicCacheStrategy;
-import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.messages.Message;
@@ -18,7 +15,6 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 
 import java.util.List;
@@ -127,8 +123,12 @@ public class SpringAiLlmService implements LlmService {
     /**
      * Builds provider-specific chat options for model selection and prompt caching.
      *
-     * <p>Anthropic uses {@code cacheStrategy} (e.g. {@code SYSTEM_AND_TOOLS}). OpenAI uses
-     * {@code promptCacheKey}. Other providers only get a model override when present.
+     * <p>Provider-specific options (Anthropic cache strategy, OpenAI prompt cache key) are
+     * applied only when the corresponding Spring AI provider module is on the classpath.
+     * Each provider's logic lives in its own class file ({@link AnthropicChatOptionsFactory},
+     * {@link OpenAiChatOptionsFactory}) which is never loaded by the JVM if the provider
+     * JAR is absent — avoiding {@link NoClassDefFoundError} in projects that don't use
+     * that provider.</p>
      */
     static ChatOptions.Builder<?> buildRequestOptions(AgentConfig agentConfig) {
         String provider = normalize(agentConfig.provider());
@@ -136,56 +136,29 @@ public class SpringAiLlmService implements LlmService {
         String cacheStrategy = blankToNull(agentConfig.cacheStrategy());
         String promptCacheKey = blankToNull(agentConfig.promptCacheKey());
 
-        if ("anthropic".equals(provider)) {
-            if (model == null && cacheStrategy == null) {
-                return null;
-            }
-            AnthropicChatOptions.Builder builder = AnthropicChatOptions.builder();
-            if (model != null) {
-                builder.model(model);
-            }
-            if (cacheStrategy != null) {
-                AnthropicCacheStrategy strategy = parseCacheStrategy(cacheStrategy);
-                AnthropicCacheOptions.Builder cacheOptions =
-                        AnthropicCacheOptions.builder().strategy(strategy);
-                if (strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY) {
-                    cacheOptions.cacheToolResults(true);
-                }
-                builder.cacheOptions(cacheOptions.build());
-            }
-            return builder;
+        if ("anthropic".equals(provider)
+                && isClassPresent("org.springframework.ai.anthropic.AnthropicChatOptions")) {
+            return new AnthropicChatOptionsFactory().build(model, cacheStrategy, promptCacheKey);
         }
 
-        if ("openai".equals(provider)) {
-            OpenAiChatOptions.Builder builder = OpenAiChatOptions.builder();
-            if (model != null) {
-                builder.model(model);
-            }
-            if (promptCacheKey != null) {
-                builder.promptCacheKey(promptCacheKey);
-            }
-            if (model == null && promptCacheKey == null) {
-                return null;
-            }
-            return builder;
+        if ("openai".equals(provider)
+                && isClassPresent("org.springframework.ai.openai.OpenAiChatOptions")) {
+            return new OpenAiChatOptionsFactory().build(model, cacheStrategy, promptCacheKey);
         }
 
+        // Generic fallback: model override only
         if (model == null) {
             return null;
         }
         return ChatOptions.builder().model(model);
     }
 
-    private static AnthropicCacheStrategy parseCacheStrategy(String raw) {
+    private static boolean isClassPresent(String className) {
         try {
-            return AnthropicCacheStrategy.valueOf(raw.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException ex) {
-            throw new IllegalStateException(
-                    "Unknown Anthropic cacheStrategy '"
-                            + raw
-                            + "'. Expected one of: NONE, TOOLS_ONLY, SYSTEM_ONLY, "
-                            + "SYSTEM_AND_TOOLS, CONVERSATION_HISTORY",
-                    ex);
+            Class.forName(className, false, SpringAiLlmService.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 

--- a/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/SpringAiLlmService.java
+++ b/agentic-subprocess/agent-llm-connector/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/SpringAiLlmService.java
@@ -8,15 +8,21 @@ import org.finos.fluxnova.bpm.engine.ai.agent.llm.tool.AgentToolSchemaConverter;
 import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
 import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
 import org.finos.fluxnova.bpm.engine.shared.model.LlmResponse;
+import org.springframework.ai.anthropic.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -85,6 +91,10 @@ public class SpringAiLlmService implements LlmService {
                 .build();
 
         ChatClient.ChatClientRequestSpec spec = client.prompt().messages(messages);
+        ChatOptions.Builder<?> options = buildRequestOptions(agentConfig);
+        if (options != null) {
+            spec = spec.options(options);
+        }
         if (!toolCallbacks.isEmpty()) {
             spec = spec.toolCallbacks(toolCallbacks);
         }
@@ -112,5 +122,78 @@ public class SpringAiLlmService implements LlmService {
         }
 
         return response;
+    }
+
+    /**
+     * Builds provider-specific chat options for model selection and prompt caching.
+     *
+     * <p>Anthropic uses {@code cacheStrategy} (e.g. {@code SYSTEM_AND_TOOLS}). OpenAI uses
+     * {@code promptCacheKey}. Other providers only get a model override when present.
+     */
+    static ChatOptions.Builder<?> buildRequestOptions(AgentConfig agentConfig) {
+        String provider = normalize(agentConfig.provider());
+        String model = blankToNull(agentConfig.model());
+        String cacheStrategy = blankToNull(agentConfig.cacheStrategy());
+        String promptCacheKey = blankToNull(agentConfig.promptCacheKey());
+
+        if ("anthropic".equals(provider)) {
+            if (model == null && cacheStrategy == null) {
+                return null;
+            }
+            AnthropicChatOptions.Builder builder = AnthropicChatOptions.builder();
+            if (model != null) {
+                builder.model(model);
+            }
+            if (cacheStrategy != null) {
+                AnthropicCacheStrategy strategy = parseCacheStrategy(cacheStrategy);
+                AnthropicCacheOptions.Builder cacheOptions =
+                        AnthropicCacheOptions.builder().strategy(strategy);
+                if (strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY) {
+                    cacheOptions.cacheToolResults(true);
+                }
+                builder.cacheOptions(cacheOptions.build());
+            }
+            return builder;
+        }
+
+        if ("openai".equals(provider)) {
+            OpenAiChatOptions.Builder builder = OpenAiChatOptions.builder();
+            if (model != null) {
+                builder.model(model);
+            }
+            if (promptCacheKey != null) {
+                builder.promptCacheKey(promptCacheKey);
+            }
+            if (model == null && promptCacheKey == null) {
+                return null;
+            }
+            return builder;
+        }
+
+        if (model == null) {
+            return null;
+        }
+        return ChatOptions.builder().model(model);
+    }
+
+    private static AnthropicCacheStrategy parseCacheStrategy(String raw) {
+        try {
+            return AnthropicCacheStrategy.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException(
+                    "Unknown Anthropic cacheStrategy '"
+                            + raw
+                            + "'. Expected one of: NONE, TOOLS_ONLY, SYSTEM_ONLY, "
+                            + "SYSTEM_AND_TOOLS, CONVERSATION_HISTORY",
+                    ex);
+        }
+    }
+
+    private static String normalize(String provider) {
+        return provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 }

--- a/agentic-subprocess/agent-llm-connector/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/parser/AgentProviderParseListenerTest.java
+++ b/agentic-subprocess/agent-llm-connector/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/parser/AgentProviderParseListenerTest.java
@@ -137,6 +137,28 @@ class AgentProviderParseListenerTest {
     }
 
     @Test
+    void parseRootElement_whenProviderIsExpression_skipsRegistryValidation() {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:agent="http://fluxnova.finos.org/schema/1.0/ai/agent">
+                  <process id="p">
+                    <adHocSubProcess id="myAgent">
+                      <extensionElements>
+                        <agent:config provider="${creditRiskAgentProvider}"
+                                      model="${creditRiskAgentModel}"
+                                      systemPrompt="You are an assistant."/>
+                      </extensionElements>
+                    </adHocSubProcess>
+                  </process>
+                </definitions>
+                """;
+
+        assertThatCode(() -> listener.parseRootElement(rootElement(bpmn), List.of()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
     void parseRootElement_whenProviderBlank_skipsValidation() {
         String bpmn = """
                 <?xml version="1.0" encoding="UTF-8"?>

--- a/agentic-subprocess/agent-llm-connector/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/SpringAiLlmServiceTest.java
+++ b/agentic-subprocess/agent-llm-connector/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/llm/service/SpringAiLlmServiceTest.java
@@ -12,6 +12,8 @@ import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
 import org.finos.fluxnova.bpm.engine.shared.model.LlmResponse;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.ai.anthropic.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
@@ -20,6 +22,7 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.beans.factory.ListableBeanFactory;
 
 import java.util.List;
@@ -35,12 +38,16 @@ class SpringAiLlmServiceTest {
 
     private final AgentToolSchemaConverter converter = new AgentToolSchemaConverter();
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private ChatModel mockChatModel(ChatResponse response) {
         ChatModel chatModel = mock(ChatModel.class);
         when(chatModel.call(any(Prompt.class))).thenReturn(response);
-        // Mock getOptions() to return a ChatOptions mock so Spring AI 2.0.0 doesn't throw NPE
+        // Mock getOptions() so Spring AI 2.0.0 can mutate/combine request options.
         ChatOptions options = mock(ChatOptions.class);
-        when(options.mutate()).thenReturn(mock(ChatOptions.Builder.class));
+        ChatOptions.Builder optionsBuilder = mock(ChatOptions.Builder.class);
+        when(options.mutate()).thenReturn(optionsBuilder);
+        when(optionsBuilder.combineWith(any())).thenReturn(optionsBuilder);
+        when(optionsBuilder.build()).thenReturn(options);
         when(chatModel.getOptions()).thenReturn(options);
         return chatModel;
     }
@@ -249,6 +256,64 @@ class SpringAiLlmServiceTest {
                 .hasMessageContaining("LLM made tool calls but no tools were provided in the request");
     }
 
+    @Test
+    void buildRequestOptions_anthropicAppliesCacheStrategy() {
+        AgentConfig config =
+                new AgentConfig(
+                        "proc-1",
+                        "agent-1",
+                        "anthropic",
+                        "claude-sonnet-5",
+                        "prompt",
+                        "agent-1",
+                        "SYSTEM_AND_TOOLS",
+                        null);
+
+        ChatOptions.Builder<?> options = SpringAiLlmService.buildRequestOptions(config);
+        assertThat(options).isInstanceOf(AnthropicChatOptions.Builder.class);
+        AnthropicChatOptions built = ((AnthropicChatOptions.Builder) options).build();
+        assertThat(built.getModel()).isEqualTo("claude-sonnet-5");
+        assertThat(built.getCacheOptions().getStrategy())
+                .isEqualTo(AnthropicCacheStrategy.SYSTEM_AND_TOOLS);
+    }
+
+    @Test
+    void buildRequestOptions_openaiAppliesPromptCacheKey() {
+        AgentConfig config =
+                new AgentConfig(
+                        "proc-1",
+                        "agent-1",
+                        "openai",
+                        "gpt-5.4",
+                        "prompt",
+                        "agent-1",
+                        null,
+                        "loan-approval");
+
+        ChatOptions.Builder<?> options = SpringAiLlmService.buildRequestOptions(config);
+        assertThat(options).isInstanceOf(OpenAiChatOptions.Builder.class);
+        OpenAiChatOptions built = ((OpenAiChatOptions.Builder) options).build();
+        assertThat(built.getModel()).isEqualTo("gpt-5.4");
+        assertThat(built.getPromptCacheKey()).isEqualTo("loan-approval");
+    }
+
+    @Test
+    void buildRequestOptions_unknownAnthropicStrategy_throws() {
+        AgentConfig config =
+                new AgentConfig(
+                        "proc-1",
+                        "agent-1",
+                        "anthropic",
+                        "claude-sonnet-5",
+                        null,
+                        "agent-1",
+                        "NOT_A_STRATEGY",
+                        null);
+
+        assertThatThrownBy(() -> SpringAiLlmService.buildRequestOptions(config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("cacheStrategy");
+    }
 
     private static AgentProviderProperties propertiesWithOverride(String providerId, String beanName) {
         AgentProviderProperties props = new AgentProviderProperties();

--- a/agentic-subprocess/agent-orchestrator/README.md
+++ b/agentic-subprocess/agent-orchestrator/README.md
@@ -69,6 +69,19 @@ The orchestrator stores all transient state as process-local variables on the sc
 | `_agentToolResultBuffer` | JSON-serialised list of results received since the last LLM call |
 | `_agentToolCallQueue` | JSON-serialised list of queued tool calls |
 
+## Dynamic provider / model / prompt
+
+`agent:config` attributes may use process-engine expressions. Definition extraction stores the raw text; each orchestration turn evaluates it against the current execution before calling the LLM:
+
+```xml
+<agent:config
+    provider="${llmProvider}"
+    model="${llmModel}"
+    systemPrompt="You are reviewing application ${applicationId}." />
+```
+
+Literal values continue to work unchanged. Composite expressions (mixed literal + `${...}`) are supported for `systemPrompt` as well. If `provider` or `model` resolves to blank, the orchestration job fails with `IllegalStateException`.
+
 ## Customisation
 
 ### Termination strategy
@@ -87,6 +100,7 @@ public AgentTerminationHandler myTerminationHandler() {
 | Class | Package | Role |
 |---|---|---|
 | `AgentOrchestrationJobHandler` | `...orchestrator.job` | Job handler that drives a single orchestration turn |
+| `AgentConfigExpressionResolver` | `...orchestrator.config` | Evaluates provider/model/systemPrompt expressions per instance |
 | `AgentStateManager` | `...orchestrator.state` | Reads and writes per-execution agent state as process variables |
 | `AgentSubprocessEntryListener` | `...orchestrator.engine` | Execution listener that enqueues the first job on scope entry |
 | `SubprocessToolCompletionListener` | `...orchestrator.engine` | Execution listener that enqueues a completion job when a tool activity ends |

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/autoconfigure/AgentOrchestratorAutoConfiguration.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/autoconfigure/AgentOrchestratorAutoConfiguration.java
@@ -50,8 +50,8 @@ public class AgentOrchestratorAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public AgentTerminationHandler adHocSubprocessTerminator() {
-        return new AdHocSubprocessTerminator();
+    public AgentTerminationHandler adHocSubprocessTerminator(AgentStateManager stateManager) {
+        return new AdHocSubprocessTerminator(stateManager);
     }
 
     @Bean

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/config/AgentConfigExpressionResolver.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/config/AgentConfigExpressionResolver.java
@@ -1,0 +1,98 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.config;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.finos.fluxnova.bpm.engine.impl.el.ExpressionManager;
+
+/**
+ * Resolves {@link AgentConfig} string fields that may contain process-engine expressions
+ * (e.g. {@code ${llmProvider}}, {@code #{llmModel}}, or composite text) against a
+ * {@link VariableScope} at orchestration time.
+ *
+ * <p>Definition-time extraction keeps the raw attribute values (including expression text).
+ * This resolver produces a per-instance {@link AgentConfig} for the LLM call.
+ */
+public final class AgentConfigExpressionResolver {
+
+    private AgentConfigExpressionResolver() {}
+
+    /**
+     * Returns a copy of {@code config} with expression-bearing string fields evaluated against
+     * {@code variableScope}.
+     *
+     * <p>When {@code expressionManager} is {@code null}, the input config is returned unchanged
+     * (useful in unit tests outside a process-engine command context).
+     *
+     * @throws IllegalStateException if provider or model resolve to blank after evaluation
+     */
+    public static AgentConfig resolve(
+            AgentConfig config, VariableScope variableScope, ExpressionManager expressionManager) {
+        if (config == null || expressionManager == null) {
+            return config;
+        }
+
+        String provider = requireResolved(
+                "provider", config.provider(), variableScope, expressionManager);
+        String model =
+                requireResolved("model", config.model(), variableScope, expressionManager);
+        String systemPrompt =
+                resolveString(config.systemPrompt(), variableScope, expressionManager);
+        String cacheStrategy =
+                blankToNull(resolveString(config.cacheStrategy(), variableScope, expressionManager));
+        String promptCacheKey =
+                blankToNull(resolveString(config.promptCacheKey(), variableScope, expressionManager));
+
+        if (unchanged(config.provider(), provider)
+                && unchanged(config.model(), model)
+                && unchanged(config.systemPrompt(), systemPrompt)
+                && unchanged(config.cacheStrategy(), cacheStrategy)
+                && unchanged(config.promptCacheKey(), promptCacheKey)) {
+            return config;
+        }
+
+        return new AgentConfig(
+                config.processDefinitionId(),
+                config.elementId(),
+                provider,
+                model,
+                systemPrompt,
+                config.toolScopeElementId(),
+                cacheStrategy,
+                promptCacheKey);
+    }
+
+    private static String requireResolved(
+            String field,
+            String raw,
+            VariableScope variableScope,
+            ExpressionManager expressionManager) {
+        String resolved = resolveString(raw, variableScope, expressionManager);
+        if (resolved == null || resolved.isBlank()) {
+            throw new IllegalStateException(
+                    "AgentConfig."
+                            + field
+                            + " resolved to a blank value (raw='"
+                            + raw
+                            + "'). Set a literal or a process variable expression that evaluates "
+                            + "to a non-blank string.");
+        }
+        return resolved;
+    }
+
+    static String resolveString(
+            String raw, VariableScope variableScope, ExpressionManager expressionManager) {
+        if (raw == null) {
+            return null;
+        }
+        Object value = expressionManager.createExpression(raw).getValue(variableScope);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static boolean unchanged(String original, String resolved) {
+        return original == null ? resolved == null : original.equals(resolved);
+    }
+}

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/engine/AdHocAgentOrchestrationParseListener.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/engine/AdHocAgentOrchestrationParseListener.java
@@ -1,8 +1,12 @@
 package org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.engine;
 
 import org.finos.fluxnova.bpm.engine.ActivityTypes;
+import org.finos.fluxnova.bpm.engine.delegate.DelegateExecution;
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.finos.fluxnova.bpm.engine.impl.Condition;
 import org.finos.fluxnova.bpm.engine.impl.bpmn.behavior.AdHocSubProcessValidationHelper;
 import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.finos.fluxnova.bpm.engine.impl.pvm.PvmEvent;
 import org.finos.fluxnova.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.finos.fluxnova.bpm.engine.impl.pvm.process.ScopeImpl;
@@ -15,6 +19,29 @@ import org.finos.fluxnova.bpm.engine.shared.agent.AgentModelConstants;
  * termination of the process, where a specific "completeAdHocSubProcess" method was implemented.
  */
 public class AdHocAgentOrchestrationParseListener extends AbstractBpmnParseListener {
+
+    /**
+     * Keeps agentic ad-hoc scopes open until {@code RuntimeService#completeAdHocSubProcess}
+     * is called. Without this, the engine's default (no-condition) behaviour completes the
+     * ad-hoc as soon as a synchronous tool activity ends, which deletes the scope while
+     * agent state variables still reference it ({@code ACT_FK_VAR_EXE}).
+     */
+    static final Condition NEVER_COMPLETE = new Condition() {
+        @Override
+        public boolean evaluate(DelegateExecution execution) {
+            return false;
+        }
+
+        @Override
+        public boolean evaluate(VariableScope scope, DelegateExecution execution) {
+            return false;
+        }
+
+        @Override
+        public boolean tryEvaluate(VariableScope scope, DelegateExecution execution) {
+            return false;
+        }
+    };
 
     private final AgentSubprocessEntryListener subprocessEntryListener;
     private final SubprocessToolCompletionListener subprocessToolCompletionListener;
@@ -38,6 +65,10 @@ public class AdHocAgentOrchestrationParseListener extends AbstractBpmnParseListe
         if (ext.elementNS(AgentModelConstants.AGENT_NS, "config") == null) {
             return;
         }
+
+        // Orchestrator owns completion; suppress engine auto-complete after tool activities.
+        activity.setProperty(BpmnParse.PROPERTYNAME_AD_HOC_COMPLETION_CONDITION, NEVER_COMPLETE);
+        activity.setProperty(BpmnParse.PROPERTYNAME_AD_HOC_COMPLETION_CONDITION_TEXT, "${false}");
 
         activity.addBuiltInListener(PvmEvent.EVENTNAME_START, subprocessEntryListener);
 

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/job/AgentOrchestrationJobHandler.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/job/AgentOrchestrationJobHandler.java
@@ -10,12 +10,16 @@ import org.finos.fluxnova.bpm.engine.ai.agent.discovery.registry.AgentToolCatalo
 import org.finos.fluxnova.bpm.engine.ai.agent.discovery.runtime.AgentContextResolver;
 import org.finos.fluxnova.bpm.engine.ai.agent.llm.service.LlmService;
 import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.config.AgentConfigExpressionResolver;
 import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.model.AgentOrchestrationConfig;
 import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.model.ToolResult;
 import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.service.AgentTerminationHandler;
 import org.finos.fluxnova.bpm.engine.ai.agent.service.ToolInvocationService;
 import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.state.AgentStateManager;
+import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.trace.AgentTraceExporter;
 import org.finos.fluxnova.bpm.engine.ai.agent.registry.AgentConfigRegistry;
+import org.finos.fluxnova.bpm.engine.impl.context.Context;
+import org.finos.fluxnova.bpm.engine.impl.el.ExpressionManager;
 import org.finos.fluxnova.bpm.engine.impl.interceptor.CommandContext;
 import org.finos.fluxnova.bpm.engine.impl.jobexecutor.JobHandler;
 import org.finos.fluxnova.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -33,15 +37,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Job handler that drives a single step of the scope execution loop.
  *
  * <p>Each execution of this handler represents one turn: it reads the current
  * conversation history and any buffered tool results from scope-local variables,
- * resolves the agent configuration and tool catalogue, calls the LLM, and then
- * either dispatches the tool activities the LLM requested or signals completion
- * of the scope if the LLM returned no tool calls.
+ * resolves the agent configuration (evaluating provider/model/systemPrompt
+ * expressions against the current execution), resolves the tool catalogue,
+ * calls the LLM, and then either dispatches the tool activities the LLM
+ * requested or signals completion of the scope if the LLM returned no tool calls.
  *
  * <p>Two entry paths are handled by a single handler type:
  * <ul>
@@ -76,6 +82,7 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
     private final ToolInvocationService toolInvocationService;
     private final AgentStateManager stateManager;
     private final AgentTerminationHandler AgentTerminationHandler;
+    private final Supplier<ExpressionManager> expressionManagerSupplier;
 
     public AgentOrchestrationJobHandler(AgentConfigRegistry agentConfigRegistry,
             AgentToolCatalogueRegistry toolCatalogueRegistry,
@@ -83,6 +90,33 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
             LlmService llmService,
             ToolInvocationService toolInvocationService, AgentStateManager stateManager,
             AgentTerminationHandler AgentTerminationHandler) {
+        this(
+                agentConfigRegistry,
+                toolCatalogueRegistry,
+                contextSpecRegistry,
+                contextResolver,
+                llmService,
+                toolInvocationService,
+                stateManager,
+                AgentTerminationHandler,
+                AgentOrchestrationJobHandler::expressionManagerFromContext);
+    }
+
+    /**
+     * Test-friendly constructor that allows injecting an {@link ExpressionManager} supplier.
+     * Production code should use the primary constructor, which resolves expressions via the
+     * active process-engine command context.
+     */
+    AgentOrchestrationJobHandler(
+            AgentConfigRegistry agentConfigRegistry,
+            AgentToolCatalogueRegistry toolCatalogueRegistry,
+            AgentContextSpecRegistry contextSpecRegistry,
+            AgentContextResolver contextResolver,
+            LlmService llmService,
+            ToolInvocationService toolInvocationService,
+            AgentStateManager stateManager,
+            AgentTerminationHandler AgentTerminationHandler,
+            Supplier<ExpressionManager> expressionManagerSupplier) {
         this.agentConfigRegistry = agentConfigRegistry;
         this.toolCatalogueRegistry = toolCatalogueRegistry;
         this.contextSpecRegistry = contextSpecRegistry;
@@ -91,6 +125,12 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
         this.toolInvocationService = toolInvocationService;
         this.stateManager = stateManager;
         this.AgentTerminationHandler = AgentTerminationHandler;
+        this.expressionManagerSupplier = expressionManagerSupplier;
+    }
+
+    private static ExpressionManager expressionManagerFromContext() {
+        var configuration = Context.getProcessEngineConfiguration();
+        return configuration == null ? null : configuration.getExpressionManager();
     }
 
     @Override
@@ -156,6 +196,10 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
         List<ConversationEntry> history = stateManager.loadHistory(runtimeService, scopeExecutionId);
         history = appendToolResults(history, buffer);
         stateManager.clearToolResultBuffer(runtimeService, scopeExecutionId);
+        if (!buffer.isEmpty()) {
+            stateManager.saveHistory(runtimeService, scopeExecutionId, history);
+            publishTrace(runtimeService, execution, scopeExecutionId);
+        }
 
         // First turn: history is empty and the mapper would send only system messages.
         // Seed a user turn so the model actually engages the tools.
@@ -167,6 +211,14 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
                 .resolve(repositoryService, execution.getProcessDefinitionId(), execution.getActivityId())
                 .orElseThrow(() -> new IllegalStateException("No AgentConfig found for "
                         + execution.getProcessDefinitionId() + "/" + execution.getActivityId()));
+        agentConfig = AgentConfigExpressionResolver.resolve(
+                agentConfig, execution, expressionManagerSupplier.get());
+        LOG.debug(
+                "Resolved AgentConfig for scope '{}': provider='{}', model='{}'",
+                scopeExecutionId,
+                agentConfig.provider(),
+                agentConfig.model());
+
         AgentToolCatalogue catalogue = toolCatalogueRegistry
                 .resolve(repositoryService, execution.getProcessDefinitionId(), execution.getActivityId())
                 .orElseThrow(() -> new IllegalStateException("No AgentToolCatalogue found for "
@@ -194,6 +246,7 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
                 llmService.call(agentConfig, catalogue, context, history);
         LOG.debug("LLM response for scope '{}': toolCalls={}", scopeExecutionId, response.toolCalls());
         stateManager.saveHistory(runtimeService, scopeExecutionId, response.updatedHistory());
+        publishTrace(runtimeService, execution, scopeExecutionId);
 
         if (response.toolCalls().isEmpty()) {
             LOG.debug("No tool calls returned, triggering termination for scope '{}'", scopeExecutionId);
@@ -254,5 +307,14 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
             updated.add(ConversationEntry.tool(result.toolCallId(), resultContent));
         }
         return updated;
+    }
+
+    private void publishTrace(
+            RuntimeService runtimeService, ExecutionEntity execution, String scopeExecutionId) {
+        AgentTraceExporter.publishToProcessInstance(
+                stateManager,
+                runtimeService,
+                scopeExecutionId,
+                execution.getProcessInstanceId());
     }
 }

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/job/AgentOrchestrationJobHandler.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/job/AgentOrchestrationJobHandler.java
@@ -245,6 +245,7 @@ public class AgentOrchestrationJobHandler implements JobHandler<AgentOrchestrati
         LlmResponse response =
                 llmService.call(agentConfig, catalogue, context, history);
         LOG.debug("LLM response for scope '{}': toolCalls={}", scopeExecutionId, response.toolCalls());
+        AgentTraceExporter.accumulateTokenUsage(runtimeService, scopeExecutionId, response.tokenUsage());
         stateManager.saveHistory(runtimeService, scopeExecutionId, response.updatedHistory());
         publishTrace(runtimeService, execution, scopeExecutionId);
 

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/service/AdHocSubprocessTerminator.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/service/AdHocSubprocessTerminator.java
@@ -1,19 +1,64 @@
 package org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.service;
 
+import java.util.Map;
+
 import org.finos.fluxnova.bpm.engine.RuntimeService;
+import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.state.AgentStateManager;
+import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.trace.AgentTraceExporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AdHocSubprocessTerminator implements AgentTerminationHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdHocSubprocessTerminator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AdHocSubprocessTerminator.class);
 
-    public AdHocSubprocessTerminator() {
+  private final AgentStateManager stateManager;
+
+  public AdHocSubprocessTerminator() {
+    this(new AgentStateManager());
+  }
+
+  public AdHocSubprocessTerminator(AgentStateManager stateManager) {
+    this.stateManager = stateManager;
+  }
+
+  @Override
+  public void complete(RuntimeService runtimeService, String scopeExecutionId) {
+    LOG.debug("complete() called for scope '{}'", scopeExecutionId);
+    Map<String, Object> traceVariables =
+        AgentTraceExporter.exportTraceVariables(stateManager, runtimeService, scopeExecutionId);
+    if (!traceVariables.isEmpty()) {
+      // Write traces to the process instance first. completeAdHocSubProcess(id, vars) applies
+      // variables on the ad-hoc scope that is about to be deleted, which can leave
+      // ACT_RU_VARIABLE rows referencing that execution (ACT_FK_VAR_EXE).
+      String processInstanceId = resolveProcessInstanceId(runtimeService, scopeExecutionId);
+      runtimeService.setVariables(processInstanceId, traceVariables);
     }
 
-    @Override
-    public void complete(RuntimeService runtimeService, String scopeExecutionId) {
-        LOG.debug("complete() called for scope '{}'", scopeExecutionId);
-        runtimeService.completeAdHocSubProcess(scopeExecutionId);
+    Map<String, Object> locals = runtimeService.getVariablesLocal(scopeExecutionId);
+    if (locals != null && !locals.isEmpty()) {
+      runtimeService.removeVariablesLocal(scopeExecutionId, locals.keySet());
     }
+
+    runtimeService.completeAdHocSubProcess(scopeExecutionId);
+  }
+
+  private static String resolveProcessInstanceId(
+      RuntimeService runtimeService, String scopeExecutionId) {
+    var byScope =
+        runtimeService
+            .createProcessInstanceQuery()
+            .processInstanceId(scopeExecutionId)
+            .singleResult();
+    if (byScope != null) {
+      return byScope.getId();
+    }
+
+    var execution =
+        runtimeService.createExecutionQuery().executionId(scopeExecutionId).singleResult();
+    if (execution == null) {
+      return scopeExecutionId;
+    }
+    return execution.getProcessInstanceId();
+  }
 }

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/trace/AgentTraceExporter.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/trace/AgentTraceExporter.java
@@ -1,0 +1,117 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.trace;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.finos.fluxnova.bpm.engine.RuntimeService;
+import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.state.AgentStateManager;
+import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
+import org.finos.fluxnova.bpm.engine.shared.model.Role;
+import org.finos.fluxnova.bpm.engine.shared.model.ToolCallRequest;
+
+/**
+ * Exports agent conversation state as process variables for traceability.
+ */
+public final class AgentTraceExporter {
+
+  public static final String VAR_LAST_RESPONSE = "agentLastResponse";
+  public static final String VAR_CONVERSATION_TRACE = "agentConversationTrace";
+  public static final String VAR_CONVERSATION_HISTORY = "agentConversationHistory";
+
+  private AgentTraceExporter() {}
+
+  public static Map<String, Object> exportTraceVariables(
+      AgentStateManager stateManager, RuntimeService runtimeService, String scopeExecutionId) {
+    List<ConversationEntry> history = stateManager.loadHistory(runtimeService, scopeExecutionId);
+    if (history.isEmpty()) {
+      return Map.of();
+    }
+
+    Map<String, Object> variables = new LinkedHashMap<>();
+    String lastResponse = extractLastAssistantMessage(history);
+    if (lastResponse != null && !lastResponse.isBlank()) {
+      variables.put(VAR_LAST_RESPONSE, lastResponse);
+    }
+
+    String trace = formatTrace(history);
+    if (!trace.isBlank()) {
+      variables.put(VAR_CONVERSATION_TRACE, trace);
+    }
+
+    String historyJson =
+        (String) runtimeService.getVariableLocal(scopeExecutionId, "_agentConversationHistory");
+    if (historyJson != null && !historyJson.isBlank()) {
+      variables.put(VAR_CONVERSATION_HISTORY, historyJson);
+    }
+
+    return variables;
+  }
+
+  /**
+   * Copies the current agent trace from the scope execution to the root process instance so it
+   * is visible in Cockpit/Monitoring while the agent is still running.
+   */
+  public static void publishToProcessInstance(
+      AgentStateManager stateManager,
+      RuntimeService runtimeService,
+      String scopeExecutionId,
+      String processInstanceId) {
+    Map<String, Object> traceVariables =
+        exportTraceVariables(stateManager, runtimeService, scopeExecutionId);
+    if (!traceVariables.isEmpty()) {
+      runtimeService.setVariables(processInstanceId, traceVariables);
+    }
+  }
+
+  static String extractLastAssistantMessage(List<ConversationEntry> history) {
+    for (int index = history.size() - 1; index >= 0; index--) {
+      ConversationEntry entry = history.get(index);
+      if (entry.role() == Role.ASSISTANT
+          && entry.content() != null
+          && !entry.content().isBlank()) {
+        return entry.content();
+      }
+    }
+    return null;
+  }
+
+  static String formatTrace(List<ConversationEntry> history) {
+    StringBuilder trace = new StringBuilder();
+    for (ConversationEntry entry : history) {
+      switch (entry.role()) {
+        case ASSISTANT -> appendAssistantEntry(trace, entry);
+        case TOOL -> appendToolEntry(trace, entry);
+        case USER -> {
+          if (entry.content() != null && !entry.content().isBlank()) {
+            trace.append("User: ").append(entry.content()).append('\n');
+          }
+        }
+        case SYSTEM -> {
+          // omitted from human-readable trace
+        }
+      }
+    }
+    return trace.toString().trim();
+  }
+
+  private static void appendAssistantEntry(StringBuilder trace, ConversationEntry entry) {
+    if (entry.content() != null && !entry.content().isBlank()) {
+      trace.append("Assistant: ").append(entry.content()).append('\n');
+    }
+    if (entry.toolCalls() != null) {
+      for (ToolCallRequest toolCall : entry.toolCalls()) {
+        trace.append("  -> tool call: ").append(toolCall.toolId()).append('\n');
+      }
+    }
+  }
+
+  private static void appendToolEntry(StringBuilder trace, ConversationEntry entry) {
+    trace.append("Tool result [").append(entry.toolCallId()).append("]: ");
+    if (entry.toolResult() == null || entry.toolResult().isEmpty()) {
+      trace.append("(empty)\n");
+      return;
+    }
+    trace.append(entry.toolResult()).append('\n');
+  }
+}

--- a/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/trace/AgentTraceExporter.java
+++ b/agentic-subprocess/agent-orchestrator/src/main/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/trace/AgentTraceExporter.java
@@ -8,16 +8,32 @@ import org.finos.fluxnova.bpm.engine.RuntimeService;
 import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.state.AgentStateManager;
 import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
 import org.finos.fluxnova.bpm.engine.shared.model.Role;
+import org.finos.fluxnova.bpm.engine.shared.model.TokenUsage;
 import org.finos.fluxnova.bpm.engine.shared.model.ToolCallRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Exports agent conversation state as process variables for traceability.
+ * Exports agent conversation state and token usage as process variables for traceability.
  */
 public final class AgentTraceExporter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AgentTraceExporter.class);
 
   public static final String VAR_LAST_RESPONSE = "agentLastResponse";
   public static final String VAR_CONVERSATION_TRACE = "agentConversationTrace";
   public static final String VAR_CONVERSATION_HISTORY = "agentConversationHistory";
+  public static final String VAR_PROMPT_TOKENS = "agentPromptTokens";
+  public static final String VAR_COMPLETION_TOKENS = "agentCompletionTokens";
+  public static final String VAR_TOTAL_TOKENS = "agentTotalTokens";
+  public static final String VAR_TOKEN_USAGE = "agentTokenUsage";
+  public static final String VAR_LLM_CALL_COUNT = "agentLlmCallCount";
+
+  // Internal scope-local variable keys for accumulation across turns
+  static final String INTERNAL_PROMPT_TOKENS = "_agentAccPromptTokens";
+  static final String INTERNAL_COMPLETION_TOKENS = "_agentAccCompletionTokens";
+  static final String INTERNAL_TOTAL_TOKENS = "_agentAccTotalTokens";
+  static final String INTERNAL_LLM_CALL_COUNT = "_agentLlmCallCount";
 
   private AgentTraceExporter() {}
 
@@ -39,13 +55,66 @@ public final class AgentTraceExporter {
       variables.put(VAR_CONVERSATION_TRACE, trace);
     }
 
-    String historyJson =
-        (String) runtimeService.getVariableLocal(scopeExecutionId, "_agentConversationHistory");
+    Object rawHistory =
+        runtimeService.getVariableLocal(scopeExecutionId, "_agentConversationHistory");
+    String historyJson = toStringValue(rawHistory);
     if (historyJson != null && !historyJson.isBlank()) {
       variables.put(VAR_CONVERSATION_HISTORY, historyJson);
     }
 
+    // Token usage variables
+    long promptTokens = loadLongVariable(runtimeService, scopeExecutionId, INTERNAL_PROMPT_TOKENS);
+    long completionTokens = loadLongVariable(runtimeService, scopeExecutionId, INTERNAL_COMPLETION_TOKENS);
+    long totalTokens = loadLongVariable(runtimeService, scopeExecutionId, INTERNAL_TOTAL_TOKENS);
+    int llmCallCount = loadIntVariable(runtimeService, scopeExecutionId, INTERNAL_LLM_CALL_COUNT);
+
+    if (llmCallCount > 0) {
+      variables.put(VAR_PROMPT_TOKENS, promptTokens);
+      variables.put(VAR_COMPLETION_TOKENS, completionTokens);
+      variables.put(VAR_TOTAL_TOKENS, totalTokens);
+      variables.put(VAR_LLM_CALL_COUNT, llmCallCount);
+      variables.put(VAR_TOKEN_USAGE, String.format(
+          "{\"promptTokens\":%d,\"completionTokens\":%d,\"totalTokens\":%d,\"llmCalls\":%d}",
+          promptTokens, completionTokens, totalTokens, llmCallCount));
+    }
+
     return variables;
+  }
+
+  /**
+   * Accumulates token usage from a single LLM call into scope-local variables.
+   * Called after each successful LLM call in the orchestration loop.
+   *
+   * @param runtimeService    the runtime service for variable access
+   * @param scopeExecutionId  the ad-hoc subprocess scope execution id
+   * @param tokenUsage        the token usage from this LLM call; may be {@code null} if the
+   *                          provider does not report usage
+   */
+  public static void accumulateTokenUsage(
+      RuntimeService runtimeService, String scopeExecutionId, TokenUsage tokenUsage) {
+    // Always increment call count
+    int callCount = loadIntVariable(runtimeService, scopeExecutionId, INTERNAL_LLM_CALL_COUNT) + 1;
+    runtimeService.setVariableLocal(scopeExecutionId, INTERNAL_LLM_CALL_COUNT, callCount);
+
+    if (tokenUsage == null) {
+      LOG.warn("LLM provider did not return token usage metadata for scope '{}', skipping token accumulation",
+          scopeExecutionId);
+      return;
+    }
+
+    long promptTokens = loadLongVariable(runtimeService, scopeExecutionId, INTERNAL_PROMPT_TOKENS)
+        + tokenUsage.promptTokens();
+    long completionTokens = loadLongVariable(runtimeService, scopeExecutionId, INTERNAL_COMPLETION_TOKENS)
+        + tokenUsage.completionTokens();
+    long totalTokens = loadLongVariable(runtimeService, scopeExecutionId, INTERNAL_TOTAL_TOKENS)
+        + tokenUsage.totalTokens();
+
+    runtimeService.setVariableLocal(scopeExecutionId, INTERNAL_PROMPT_TOKENS, promptTokens);
+    runtimeService.setVariableLocal(scopeExecutionId, INTERNAL_COMPLETION_TOKENS, completionTokens);
+    runtimeService.setVariableLocal(scopeExecutionId, INTERNAL_TOTAL_TOKENS, totalTokens);
+
+    LOG.debug("Token usage for scope '{}': prompt={}, completion={}, total={}, callCount={}",
+        scopeExecutionId, promptTokens, completionTokens, totalTokens, callCount);
   }
 
   /**
@@ -113,5 +182,44 @@ public final class AgentTraceExporter {
       return;
     }
     trace.append(entry.toolResult()).append('\n');
+  }
+
+  /**
+   * Converts a process variable value to String, handling the case where the engine
+   * stores large strings as {@code byte[]} (binary serialization).
+   */
+  private static String toStringValue(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof String s) {
+      return s;
+    }
+    if (value instanceof byte[] bytes) {
+      return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+    }
+    return value.toString();
+  }
+
+  private static long loadLongVariable(RuntimeService runtimeService, String executionId, String name) {
+    Object value = runtimeService.getVariableLocal(executionId, name);
+    if (value == null) {
+      return 0L;
+    }
+    if (value instanceof Number n) {
+      return n.longValue();
+    }
+    return 0L;
+  }
+
+  private static int loadIntVariable(RuntimeService runtimeService, String executionId, String name) {
+    Object value = runtimeService.getVariableLocal(executionId, name);
+    if (value == null) {
+      return 0;
+    }
+    if (value instanceof Number n) {
+      return n.intValue();
+    }
+    return 0;
   }
 }

--- a/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/config/AgentConfigExpressionResolverTest.java
+++ b/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/config/AgentConfigExpressionResolverTest.java
@@ -1,0 +1,180 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.config;
+
+import org.finos.fluxnova.bpm.engine.ai.agent.model.AgentConfig;
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.finos.fluxnova.bpm.engine.impl.el.Expression;
+import org.finos.fluxnova.bpm.engine.impl.el.ExpressionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentConfigExpressionResolverTest {
+
+    private static final String PROC_DEF_ID = "proc:1";
+    private static final String ELEMENT_ID = "agentSubprocess";
+
+    @Mock
+    private VariableScope variableScope;
+
+    @Mock
+    private ExpressionManager expressionManager;
+
+    @Test
+    void resolve_whenExpressionManagerNull_returnsSameInstance() {
+        AgentConfig config = literalConfig("openai", "gpt-5.4", "Be careful.");
+
+        assertSame(config, AgentConfigExpressionResolver.resolve(config, variableScope, null));
+    }
+
+    @Test
+    void resolve_evaluatesProviderModelAndSystemPrompt() {
+        AgentConfig config =
+                literalConfig("${llmProvider}", "${llmModel}", "Decide for ${applicantName}");
+        stubExpression("${llmProvider}", "anthropic");
+        stubExpression("${llmModel}", "claude-sonnet-4-6");
+        stubExpression("Decide for ${applicantName}", "Decide for Ada");
+
+        AgentConfig resolved =
+                AgentConfigExpressionResolver.resolve(config, variableScope, expressionManager);
+
+        assertEquals("anthropic", resolved.provider());
+        assertEquals("claude-sonnet-4-6", resolved.model());
+        assertEquals("Decide for Ada", resolved.systemPrompt());
+        assertEquals(PROC_DEF_ID, resolved.processDefinitionId());
+        assertEquals(ELEMENT_ID, resolved.elementId());
+        assertEquals(ELEMENT_ID, resolved.toolScopeElementId());
+    }
+
+    @Test
+    void resolve_evaluatesCacheStrategyAndPromptCacheKey() {
+        AgentConfig config =
+                new AgentConfig(
+                        PROC_DEF_ID,
+                        ELEMENT_ID,
+                        "anthropic",
+                        "claude-sonnet-5",
+                        null,
+                        ELEMENT_ID,
+                        "${cacheStrategy}",
+                        "${promptCacheKey}");
+        stubExpression("anthropic", "anthropic");
+        stubExpression("claude-sonnet-5", "claude-sonnet-5");
+        stubExpression("${cacheStrategy}", "SYSTEM_AND_TOOLS");
+        stubExpression("${promptCacheKey}", "loan-approval");
+
+        AgentConfig resolved =
+                AgentConfigExpressionResolver.resolve(config, variableScope, expressionManager);
+
+        assertEquals("SYSTEM_AND_TOOLS", resolved.cacheStrategy());
+        assertEquals("loan-approval", resolved.promptCacheKey());
+    }
+
+    @Test
+    void resolve_blankCacheFieldsBecomeNull() {
+        AgentConfig config =
+                new AgentConfig(
+                        PROC_DEF_ID,
+                        ELEMENT_ID,
+                        "openai",
+                        "gpt-5.4",
+                        null,
+                        ELEMENT_ID,
+                        "${cacheStrategy}",
+                        "${promptCacheKey}");
+        stubExpression("openai", "openai");
+        stubExpression("gpt-5.4", "gpt-5.4");
+        stubExpression("${cacheStrategy}", "  ");
+        stubExpression("${promptCacheKey}", null);
+
+        AgentConfig resolved =
+                AgentConfigExpressionResolver.resolve(config, variableScope, expressionManager);
+
+        assertEquals(null, resolved.cacheStrategy());
+        assertEquals(null, resolved.promptCacheKey());
+    }
+
+    @Test
+    void resolve_whenAllLiteralsUnchanged_returnsSameInstance() {
+        AgentConfig config = literalConfig("openai", "gpt-5.4", "Be careful.");
+        stubExpression("openai", "openai");
+        stubExpression("gpt-5.4", "gpt-5.4");
+        stubExpression("Be careful.", "Be careful.");
+
+        AgentConfig resolved =
+                AgentConfigExpressionResolver.resolve(config, variableScope, expressionManager);
+
+        assertSame(config, resolved);
+    }
+
+    @Test
+    void resolve_whenProviderResolvesBlank_throws() {
+        AgentConfig config = literalConfig("${missingProvider}", "gpt-5.4", null);
+        stubExpression("${missingProvider}", "  ");
+
+        IllegalStateException ex =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> AgentConfigExpressionResolver.resolve(
+                                config, variableScope, expressionManager));
+
+        assertTrue(ex.getMessage().contains("provider"));
+    }
+
+    @Test
+    void resolve_whenModelResolvesNull_throws() {
+        AgentConfig config = literalConfig("openai", "${missingModel}", null);
+        stubExpression("openai", "openai");
+        stubExpression("${missingModel}", null);
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> AgentConfigExpressionResolver.resolve(
+                        config, variableScope, expressionManager));
+    }
+
+    @Test
+    void resolve_allowsNullSystemPrompt() {
+        AgentConfig config = literalConfig("openai", "gpt-5.4", null);
+        stubExpression("openai", "openai");
+        stubExpression("gpt-5.4", "gpt-5.4");
+
+        AgentConfig resolved =
+                AgentConfigExpressionResolver.resolve(config, variableScope, expressionManager);
+
+        assertSame(config, resolved);
+        assertEquals(null, resolved.systemPrompt());
+    }
+
+    @Test
+    void resolve_stringifiesNonStringExpressionResults() {
+        AgentConfig config = literalConfig("${providerObj}", "${modelObj}", null);
+        stubExpression("${providerObj}", 42);
+        stubExpression("${modelObj}", true);
+
+        AgentConfig resolved =
+                AgentConfigExpressionResolver.resolve(config, variableScope, expressionManager);
+
+        assertEquals("42", resolved.provider());
+        assertEquals("true", resolved.model());
+    }
+
+    private AgentConfig literalConfig(String provider, String model, String systemPrompt) {
+        return new AgentConfig(
+                PROC_DEF_ID, ELEMENT_ID, provider, model, systemPrompt, ELEMENT_ID);
+    }
+
+    private void stubExpression(String expressionText, Object value) {
+        Expression expression = mock(Expression.class);
+        when(expressionManager.createExpression(expressionText)).thenReturn(expression);
+        when(expression.getValue(variableScope)).thenReturn(value);
+    }
+}

--- a/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/engine/AdHocAgentOrchestrationParseListenerTest.java
+++ b/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/engine/AdHocAgentOrchestrationParseListenerTest.java
@@ -90,6 +90,12 @@ class AdHocAgentOrchestrationParseListenerTest {
             parseListener.parseSubProcess(element, scope, activity);
 
             verify(activity).addBuiltInListener(PvmEvent.EVENTNAME_START, entryListener);
+            verify(activity).setProperty(
+                    org.finos.fluxnova.bpm.engine.impl.bpmn.parser.BpmnParse.PROPERTYNAME_AD_HOC_COMPLETION_CONDITION,
+                    AdHocAgentOrchestrationParseListener.NEVER_COMPLETE);
+            verify(activity).setProperty(
+                    org.finos.fluxnova.bpm.engine.impl.bpmn.parser.BpmnParse.PROPERTYNAME_AD_HOC_COMPLETION_CONDITION_TEXT,
+                    "${false}");
         }
 
         @Test

--- a/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/job/AgentOrchestrationJobHandlerTest.java
+++ b/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/job/AgentOrchestrationJobHandlerTest.java
@@ -18,6 +18,8 @@ import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.service.AgentTerminat
 import org.finos.fluxnova.bpm.engine.ai.agent.service.ToolInvocationService;
 import org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.state.AgentStateManager;
 import org.finos.fluxnova.bpm.engine.ai.agent.registry.AgentConfigRegistry;
+import org.finos.fluxnova.bpm.engine.impl.el.Expression;
+import org.finos.fluxnova.bpm.engine.impl.el.ExpressionManager;
 import org.finos.fluxnova.bpm.engine.impl.interceptor.CommandContext;
 import org.finos.fluxnova.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.finos.fluxnova.bpm.engine.impl.persistence.entity.JobManager;
@@ -124,6 +126,16 @@ class AgentOrchestrationJobHandlerTest {
                 when(stateManager.loadToolResultBuffer(runtimeService, SCOPE_EXECUTION_ID))
                                 .thenReturn(new ArrayList<>());
                 when(stateManager.loadHistory(runtimeService, SCOPE_EXECUTION_ID)).thenReturn(new ArrayList<>());
+        }
+
+        private static void stubExpression(
+                        ExpressionManager expressionManager,
+                        ExecutionEntity execution,
+                        String expressionText,
+                        Object value) {
+                Expression expression = mock(Expression.class);
+                when(expressionManager.createExpression(expressionText)).thenReturn(expression);
+                when(expression.getValue(execution)).thenReturn(value);
         }
 
         @Test
@@ -276,6 +288,66 @@ class AgentOrchestrationJobHandlerTest {
                         assertThrows(IllegalStateException.class,
                                         () -> handler.execute(AgentOrchestrationConfig.forEntry(),
                                                         execution, commandContext, null));
+                }
+
+                @Test
+                void execute_resolvesAgentConfigExpressionsBeforeLlmCall() {
+                        AgentConfig template = new AgentConfig(
+                                        PROC_DEF_ID,
+                                        ELEMENT_ID,
+                                        "${llmProvider}",
+                                        "${llmModel}",
+                                        "Review ${loanPurpose}",
+                                        ELEMENT_ID);
+                        when(agentConfigRegistry.resolve(repositoryService, PROC_DEF_ID, ELEMENT_ID))
+                                        .thenReturn(Optional.of(template));
+                        when(toolCatalogueRegistry.resolve(repositoryService, PROC_DEF_ID, ELEMENT_ID))
+                                        .thenReturn(Optional.of(toolCatalogue));
+                        when(contextSpecRegistry.resolve(repositoryService, PROC_DEF_ID, ELEMENT_ID))
+                                        .thenReturn(Optional.of(contextSpec));
+                        stubEmptyState();
+
+                        ExpressionManager expressionManager = mock(ExpressionManager.class);
+                        stubExpression(expressionManager, execution, "${llmProvider}", "anthropic");
+                        stubExpression(expressionManager, execution, "${llmModel}", "claude-sonnet-4-6");
+                        stubExpression(
+                                        expressionManager,
+                                        execution,
+                                        "Review ${loanPurpose}",
+                                        "Review home improvement");
+
+                        handler = new AgentOrchestrationJobHandler(
+                                        agentConfigRegistry,
+                                        toolCatalogueRegistry,
+                                        contextSpecRegistry,
+                                        contextResolver,
+                                        llmService,
+                                        toolInvocationService,
+                                        stateManager,
+                                        terminationHandler,
+                                        () -> expressionManager);
+
+                        ResolvedContext resolvedContext = new ResolvedContext(Map.of());
+                        when(contextResolver.resolve(runtimeService, SCOPE_EXECUTION_ID, contextSpec))
+                                        .thenReturn(resolvedContext);
+
+                        AgentConfig expected = new AgentConfig(
+                                        PROC_DEF_ID,
+                                        ELEMENT_ID,
+                                        "anthropic",
+                                        "claude-sonnet-4-6",
+                                        "Review home improvement",
+                                        ELEMENT_ID);
+                        LlmResponse response = new LlmResponse(
+                                        "Done",
+                                        List.of(),
+                                        List.of(ConversationEntry.assistant("Done", List.of())));
+                        when(llmService.call(eq(expected), eq(toolCatalogue), eq(resolvedContext), anyList()))
+                                        .thenReturn(response);
+
+                        handler.execute(AgentOrchestrationConfig.forEntry(), execution, commandContext, null);
+
+                        verify(llmService).call(eq(expected), eq(toolCatalogue), eq(resolvedContext), anyList());
                 }
         }
 

--- a/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/trace/AgentTraceExporterTest.java
+++ b/agentic-subprocess/agent-orchestrator/src/test/java/org/finos/fluxnova/bpm/engine/ai/agent/orchestrator/trace/AgentTraceExporterTest.java
@@ -1,0 +1,41 @@
+package org.finos.fluxnova.bpm.engine.ai.agent.orchestrator.trace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.finos.fluxnova.bpm.engine.shared.model.ConversationEntry;
+import org.finos.fluxnova.bpm.engine.shared.model.ToolCallRequest;
+import org.junit.jupiter.api.Test;
+
+class AgentTraceExporterTest {
+
+  @Test
+  void formatTrace_includesAssistantMessagesToolCallsAndToolOutputs() {
+    List<ConversationEntry> history =
+        List.of(
+            ConversationEntry.assistant(
+                "Checking credit profile.",
+                List.of(new ToolCallRequest("tc-1", "ServiceTask_CreditScoreCheck"))),
+            ConversationEntry.tool(
+                "tc-1",
+                Map.of(
+                    "status",
+                    "ok",
+                    "toolElementId",
+                    "ServiceTask_CreditScoreCheck",
+                    "outputs",
+                    Map.of("creditScore", 710, "aiRiskScore", 0.25))),
+            ConversationEntry.assistant("Credit profile reviewed.", List.of()));
+
+    String trace = AgentTraceExporter.formatTrace(history);
+
+    assertTrue(trace.contains("Assistant: Checking credit profile."));
+    assertTrue(trace.contains("-> tool call: ServiceTask_CreditScoreCheck"));
+    assertTrue(trace.contains("creditScore=710"));
+    assertTrue(trace.contains("Assistant: Credit profile reviewed."));
+    assertEquals("Credit profile reviewed.", AgentTraceExporter.extractLastAssistantMessage(history));
+  }
+}

--- a/agentic-subprocess/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/model/LlmResponse.java
+++ b/agentic-subprocess/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/model/LlmResponse.java
@@ -2,6 +2,17 @@ package org.finos.fluxnova.bpm.engine.shared.model;
 
 import java.util.List;
 
-public record LlmResponse(String assistantText, List<ToolCallRequest> toolCalls,
-        List<ConversationEntry> updatedHistory) {
+public record LlmResponse(
+    String assistantText,
+    List<ToolCallRequest> toolCalls,
+    List<ConversationEntry> updatedHistory,
+    TokenUsage tokenUsage) {
+
+  public LlmResponse(
+      String assistantText,
+      List<ToolCallRequest> toolCalls,
+      List<ConversationEntry> updatedHistory) {
+    this(assistantText, toolCalls, updatedHistory, null);
+  }
+
 }

--- a/agentic-subprocess/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/model/TokenUsage.java
+++ b/agentic-subprocess/shared/src/main/java/org/finos/fluxnova/bpm/engine/shared/model/TokenUsage.java
@@ -1,0 +1,34 @@
+package org.finos.fluxnova.bpm.engine.shared.model;
+
+/**
+ * Token consumption reported by an LLM provider for a single completion request.
+ *
+ * <p>{@code cacheReadInputTokens} are tokens served from a prompt cache (billed at the cache-input
+ * rate). {@code cacheWriteInputTokens} are tokens written into the cache (billed at the cache-write
+ * rate). Provider reporting differs: OpenAI includes cache reads inside {@code promptTokens};
+ * Anthropic typically reports cache buckets separately from {@code promptTokens}.
+ */
+public record TokenUsage(
+    int promptTokens,
+    int completionTokens,
+    int totalTokens,
+    int cacheReadInputTokens,
+    int cacheWriteInputTokens) {
+
+  public TokenUsage {
+    if (totalTokens <= 0 && (promptTokens > 0 || completionTokens > 0)) {
+      totalTokens = promptTokens + completionTokens;
+    }
+    if (cacheReadInputTokens < 0) {
+      cacheReadInputTokens = 0;
+    }
+    if (cacheWriteInputTokens < 0) {
+      cacheWriteInputTokens = 0;
+    }
+  }
+
+  /** Convenience constructor when cache token counts are unavailable. */
+  public TokenUsage(int promptTokens, int completionTokens, int totalTokens) {
+    this(promptTokens, completionTokens, totalTokens, 0, 0);
+  }
+}


### PR DESCRIPTION
Carry TokenUsage (including cache read/write) through agent LLM responses, resolve provider/model/cacheStrategy/promptCacheKey expressions per instance, apply Anthropic/OpenAI cache options, and export conversation trace variables.